### PR TITLE
reset the stats received gauge on each poll

### DIFF
--- a/surveyor/collector_statz.go
+++ b/surveyor/collector_statz.go
@@ -427,6 +427,7 @@ func (sc *StatzCollector) Collect(ch chan<- prometheus.Metric) {
 	defer sc.Unlock()
 
 	ch <- sc.newNatsUpGaugeMetric(true)
+	sc.surveyedCnt.WithLabelValues().Set(0)
 
 	for _, sm := range sc.stats {
 		sc.surveyedCnt.WithLabelValues().Inc()


### PR DESCRIPTION
Appears the intention here was not to make a metric/sec style
counter but rather a gauge of scrapes received per poll and indeed
that is a more useful number to keep