### PR TITLE
Add username/password authentication

### DIFF
--- a/main.go
+++ b/main.go
@@ -37,7 +37,7 @@ func main() {
 	flag.BoolVar(&printVersion, "version", false, "Show exporter version and exit.")
 	flag.StringVar(&opts.URLs, "s", "nats://localhost:4222", "NATS Cluster url(s)")
 	flag.StringVar(&opts.Credentials, "creds", "", "Credentials File")
-	flag.StringVar(&opts.NATSUser, "user", "", "NATS user name")
+	flag.StringVar(&opts.NATSUser, "user", "", "NATS user name or token")
 	flag.StringVar(&opts.NATSPassword, "password", "", "NATS user password")
 	flag.IntVar(&opts.ExpectedServers, "c", 1, "Expected number of servers")
 	flag.DurationVar(&opts.PollTimeout, "timeout", 3*time.Second, "Polling timeout")

--- a/main.go
+++ b/main.go
@@ -37,6 +37,8 @@ func main() {
 	flag.BoolVar(&printVersion, "version", false, "Show exporter version and exit.")
 	flag.StringVar(&opts.URLs, "s", "nats://localhost:4222", "NATS Cluster url(s)")
 	flag.StringVar(&opts.Credentials, "creds", "", "Credentials File")
+	flag.StringVar(&opts.NATSUser, "user", "", "NATS user name")
+	flag.StringVar(&opts.NATSPassword, "password", "", "NATS user password")
 	flag.IntVar(&opts.ExpectedServers, "c", 1, "Expected number of servers")
 	flag.DurationVar(&opts.PollTimeout, "timeout", 3*time.Second, "Polling timeout")
 	flag.IntVar(&opts.ListenPort, "port", surveyor.DefaultListenPort, "Port to listen on.")

--- a/surveyor/surveyor.go
+++ b/surveyor/surveyor.go
@@ -53,6 +53,8 @@ type Options struct {
 	Name                 string
 	URLs                 string
 	Credentials          string
+	NATSUser             string
+	NATSPassword         string
 	PollTimeout          time.Duration
 	ExpectedServers      int
 	ListenAddress        string
@@ -108,6 +110,8 @@ func connect(opts *Options) (*nats.Conn, error) {
 	nopts := []nats.Option{nats.Name(opts.Name)}
 	if opts.Credentials != "" {
 		nopts = append(nopts, nats.UserCredentials(opts.Credentials))
+	} else if opts.NATSUser != "" {
+		nopts = append(nopts, nats.UserInfo(opts.NATSUser, opts.NATSPassword))
 	}
 
 	nopts = append(nopts, nats.DisconnectHandler(func(_ *nats.Conn) {

--- a/surveyor/surveyor_test.go
+++ b/surveyor/surveyor_test.go
@@ -411,6 +411,7 @@ func TestSurveyor_ConcurrentBlock(t *testing.T) {
 	if err = s.Start(); err != nil {
 		t.Fatalf("start error: %v", err)
 	}
+	defer s.Stop()
 
 	s.statzC.polling = true
 	_, err = pollAndCheckDefault(t, "nats_core_mem_bytes")
@@ -451,7 +452,7 @@ func TestSurveyor_NATSUserPass(t *testing.T) {
 	}
 	defer s.Stop()
 
-	if _, err = PollSurveyorEndpoint(t, "http://colin:secret@127.0.0.1:7777/metrics", false, http.StatusOK); err != nil {
+	if _, err = PollSurveyorEndpoint(t, "http://127.0.0.1:7777/metrics", false, http.StatusOK); err != nil {
 		t.Fatalf("received unexpected error: %v", err)
 	}
 }

--- a/surveyor/surveyor_test.go
+++ b/surveyor/surveyor_test.go
@@ -422,3 +422,36 @@ func TestSurveyor_ConcurrentBlock(t *testing.T) {
 		t.Fatalf("Expected 503 error but got: %v", err)
 	}
 }
+
+func TestSurveyor_NATSUserPass(t *testing.T) {
+	ns := st.StartServer(t, "../test/trad.conf")
+	defer ns.Shutdown()
+
+	opts := getTestOptions()
+	opts.Credentials = ""
+
+	opts.NATSUser = "invalid_user"
+	opts.NATSPassword = "password"
+	_, err := NewSurveyor(opts)
+	if err == nil {
+		t.Fatalf("didn't receive expected error")
+	}
+	if !strings.Contains(err.Error(), "Auth") {
+		t.Fatalf("didn't receive expected error: %v", err)
+	}
+
+	opts.NATSUser = "sys"
+	opts.NATSPassword = "password"
+	s, err := NewSurveyor(opts)
+	if err != nil {
+		t.Fatalf("couldn't create surveyor: %v", err)
+	}
+	if err = s.Start(); err != nil {
+		t.Fatalf("start error: %v", err)
+	}
+	defer s.Stop()
+
+	if _, err = PollSurveyorEndpoint(t, "http://colin:secret@127.0.0.1:7777/metrics", false, http.StatusOK); err != nil {
+		t.Fatalf("received unexpected error: %v", err)
+	}
+}

--- a/test/test.go
+++ b/test/test.go
@@ -100,12 +100,12 @@ func StartServer(t *testing.T, confFile string) *ns.Server {
 	resetPreviousHTTPConnections()
 	opts, err := ns.ProcessConfigFile(confFile)
 
-	// remove this line for debugging
-	opts.NoLog = true
-
 	if err != nil {
 		t.Fatalf("Error processing config file: %v", err)
 	}
+
+	// remove this line for debugging
+	opts.NoLog = true
 
 	s, err := ns.NewServer(opts)
 	if err != nil || s == nil {

--- a/test/trad.conf
+++ b/test/trad.conf
@@ -1,0 +1,8 @@
+accounts: {
+    SYS: { 
+        users: [
+            {user: sys, password: password}
+        ]
+    },
+}
+system_account: SYS


### PR DESCRIPTION
Support username/password authentication with the NATS server.  Note, this still requires a system account.

Example server configuration:

```text
accounts: {
    SYS: { 
        users: [
            {user: sys, password: password}
        ]
    },
}
```

Corresponding command line:

`$ nats-surveyor -user sys -password password`

Resolves #8 

Signed-off-by: Colin Sullivan <colin@synadia.com>