### PR TITLE
Observations: add nkey support + prevent same observation from being loaded twice in k8s

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Usage of ./nats-surveyor:
   -creds string
     	Credentials File for the system account when using jwt authentication
   -nkey string
-      NKey File for the system account when using nkey authenication
+      NKey Seed File for the system account when using nkey authenication
   -http_pass string
     	Set the password for HTTP scrapes. NATS bcrypt supported.
   -http_user string
@@ -341,13 +341,24 @@ More information can be found [here](https://github.com/prometheus/prometheus/is
 
 ## Service Observations
 
-Services can be observed by creating JSON files in the `observations` directory, here's an example:
+Services can be observed by creating JSON files in the `observations` directory.
+Both jwt credential files and nkey seed files are supported. The name of the observation has to unique. A second observation with a duplicate name will be ignored.
+
+Here's an example using a jwt credential file:
 
 ```json
 {
   "name": "email.subscribe",
   "topic": "monitor.email.subscribe",
   "credential": "/observations/email.subscribe.cred"
+}
+``` 
+Example with nkey seed file:
+```json
+{
+  "name": "email.subscribe",
+  "topic": "monitor.email.subscribe",
+  "nkey": "/observations/email.subscribe.nkey"
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,9 @@ Usage of ./nats-surveyor:
   -c int
     	Expected number of servers (default 1)
   -creds string
-    	Credentials File for the system account
+    	Credentials File for the system account when using jwt authentication
+  -nkey string
+      NKey File for the system account when using nkey authenication
   -http_pass string
     	Set the password for HTTP scrapes. NATS bcrypt supported.
   -http_user string

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/nats-io/nats-surveyor
 go 1.13
 
 require (
+	github.com/google/go-cmp v0.4.0
 	github.com/nats-io/jsm.go v0.0.18-0.20200730120250-1c385c865112
 	github.com/nats-io/nats-server/v2 v2.1.8-0.20200727232909-fbab1daf063e
 	github.com/nats-io/nats.go v1.10.1-0.20200606002146-fc6fed82929a

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,6 @@ module github.com/nats-io/nats-surveyor
 go 1.13
 
 require (
-	github.com/google/go-cmp v0.4.0
 	github.com/nats-io/jsm.go v0.0.18-0.20200730120250-1c385c865112
 	github.com/nats-io/nats-server/v2 v2.1.8-0.20200727232909-fbab1daf063e
 	github.com/nats-io/nats.go v1.10.1-0.20200606002146-fc6fed82929a

--- a/surveyor/surveyor.go
+++ b/surveyor/surveyor.go
@@ -30,7 +30,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/google/go-cmp/cmp"
 	nats "github.com/nats-io/nats.go"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
@@ -455,7 +454,7 @@ func (s *Surveyor) startObservations() error {
 		// Prevent an equal observation to be loaded twice
 		// This is a problem that occurs with k8s mounts
 		for _, existingObservation := range s.observations {
-			if cmp.Equal(obs.opts, existingObservation.opts) {
+			if obs.opts.ServiceName == existingObservation.opts.ServiceName {
 				return nil
 			}
 		}

--- a/surveyor/surveyor.go
+++ b/surveyor/surveyor.go
@@ -452,8 +452,10 @@ func (s *Surveyor) startObservations() error {
 			return fmt.Errorf("could not create observation from %s: %s", path, err)
 		}
 
-		for _, o := range s.observations {
-			if cmp.Equal(obs.opts, o.opts) {
+		// Prevent an equal observation to be loaded twice
+		// This is a problem that occurs with k8s mounts
+		for _, existingObservation := range s.observations {
+			if cmp.Equal(obs.opts, existingObservation.opts) {
 				return nil
 			}
 		}

--- a/surveyor/surveyor.go
+++ b/surveyor/surveyor.go
@@ -30,6 +30,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/google/go-cmp/cmp"
 	nats "github.com/nats-io/nats.go"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
@@ -449,6 +450,12 @@ func (s *Surveyor) startObservations() error {
 		obs, err := NewServiceObservation(path, s.opts)
 		if err != nil {
 			return fmt.Errorf("could not create observation from %s: %s", path, err)
+		}
+
+		for _, o := range s.observations {
+			if cmp.Equal(obs.opts, o.opts) {
+				return nil
+			}
 		}
 
 		err = obs.Start()


### PR DESCRIPTION
Added the ability to use nkeys for configuring observations.
Observation with nkey would look like this:
```
{
  "name": "email.subscribe",
  "topic": "monitor.email.subscribe",
  "nkey": "/observations/email.subscribe.nkey"
}
```

Also solves an issue I had with observations on Kubernetes.
I would mount the observations as a volume to the nats-surveyor deployment using a configmap. When mounting a observations json file it, kubernetes makes soft links like this:
```
/observations # ls -al
drwxrwxrwx    3 root     root          4096 Nov  6 18:37 .
drwxr-xr-x    3 root     root          4096 Nov  6 18:37 ..
drwxr-xr-x    2 root     root          4096 Nov  6 18:37 ..2020_11_06_18_37_09.212523381
lrwxrwxrwx    1 root     root            31 Nov  6 18:37 ..data -> ..2020_11_06_18_37_09.212523381
lrwxrwxrwx    1 root     root            32 Nov  6 18:37 observation.json -> ..data/observation.json
```
This results in nats-surveyor loading each observations twice, due to nats-surveyor iterating over all the files and directories contained in the directory which was provided at startup.
I tried to solve this by comparing new observations with the pre-existing observations and ignoring already added observations.
I didn't program in Go before, so there's probably a better solution for this issue?