### PR TITLE
Add multiarch rules

### DIFF
--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -5,7 +5,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go: [1.14]
+        go: [1.16]
         os: [ubuntu-latest, macOS-latest]
     runs-on: ${{matrix.os}}
     steps:

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,13 @@
+.PHONY: dockerx
+dockerx:
+ifneq ($(ver),)
+	# Ensure 'docker buildx ls' shows correct platforms.
+	docker buildx build \
+		--tag natsio/nats-surveyor:$(ver) --tag natsio/nats-surveyor:latest \
+		--platform linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64/v8 \
+		--push .
+else
+	# Missing version, try this.
+	# make dockerx ver=1.2.3
+	exit 1
+endif

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/nats-io/nats-surveyor
 
-go 1.14
+go 1.16
 
 require (
 	github.com/minio/highwayhash v1.0.1 // indirect


### PR DESCRIPTION
This adds rules to build multi-arch Docker images. A working BuildKit builder is required for creating these images. See more documentation at: https://docs.docker.com/buildx/working-with-buildx

Assuming a working builder, then all we need to do is this.
```
make dockerx ver=1.2.3
```

These are the arches that are created:
![image](https://user-images.githubusercontent.com/4296393/128097374-facb7a8b-1759-4f61-b456-5f112af984c8.png)

I tested the linux/arm64 images on Ubuntu ARM64.
```
$ uname -a
Linux aws #43~20.04.1-Ubuntu SMP Thu Jul 15 11:03:27 UTC 2021 aarch64 aarch64 aarch64 GNU/Linux
```