### PR TITLE
Add support for mTLS authentication on Jetstream

### DIFF
--- a/README.md
+++ b/README.md
@@ -366,8 +366,14 @@ Place this in `observations/email.surbscribe.json` and create a credential givin
 
 ## JetStream
 
-JetStream can be monitored on a per-account basis by creating JSON files in the `jetstream` directory, here's an example:
+JetStream can be monitored on a per-account basis by creating JSON files in the `jetstream` directory.
+Place those files in `jetstream/youraccount.json`. Be sure that you give access to the `$JS.EVENT.>` subject to your user. 
 
+When you add/modify account files, you'll need restart the NATS Surveyor service in order for the JetStream in this account to be monitored.
+
+There are some ways to establish authentication, here are some examples:
+
+### Credentials
 ```json
 {
   "name": "Your Account",
@@ -375,7 +381,32 @@ JetStream can be monitored on a per-account basis by creating JSON files in the 
 }
 ```
 
-Place this in `jetstream/youraccount.json` and create a credential giving access to `$JS.EVENT.>` in `jetstream/youraccount.cred`, when you restart the service JetStream in this account will be monitored.
+### User/Password
+```json
+{
+  "name": "Your Account",
+  "username": "accounta",
+  "password": "changeit"
+}
+```
+
+### NKeys 
+```json
+{
+  "name": "Your Account",
+  "nkey": "UDXU4RCSJNZOIQHZNWXHXORDPRTGNJAHAHFRGZNEEJCPQTT2M7NLCNF4"
+}
+```
+### mTLS
+
+```json
+{
+  "name": "Your Account",
+  "tls_ca": "/etc/nats-certs/your-account/ca.crt",
+  "tls_cert": "/etc/nats-certs/your-account/tls.crt",
+  "tls_key": "/etc/nats-certs/your-account/tls.key"
+}
+```
 
 ## TODO
 

--- a/surveyor/jetstream_advisories.go
+++ b/surveyor/jetstream_advisories.go
@@ -44,6 +44,9 @@ type jsAdvisoryOptions struct {
 	Username    string `json:"username"`
 	Password    string `json:"password"`
 	NKey        string `json:"nkey"`
+	TLSCert     string `json:"tls_cert"`
+	TLSKey      string `json:"tls_key"`
+	TLSCA       string `json:"tls_ca"`
 }
 
 // Validate checks the options meet our expectations
@@ -228,6 +231,12 @@ func NewJetStreamAdvisoryListener(f string, sopts Options) (*JSAdvisoryListener,
 	sopts.NATSUser = opts.Username
 	sopts.NATSPassword = opts.Password
 	sopts.Nkey = opts.NKey
+
+	if opts.TLSKey != "" && opts.TLSCert != "" && opts.TLSCA != "" {
+		sopts.CaFile = opts.TLSCA
+		sopts.CertFile = opts.TLSCert
+		sopts.KeyFile = opts.TLSKey
+	}
 
 	nc, err := connect(&sopts)
 	if err != nil {


### PR DESCRIPTION
Work towards [this](https://github.com/nats-io/nats-surveyor/issues/53) issue.

- Changed Account File schema to support references to mTLS certificates.
- Added support to load the account mTLS certificates when authenticating
with Jetstream.
- Updated documentation to include other ways to authenticate with NATS
Jetstream.

Co-authored-by: David Peinado-sempere <david.peinado-sempere@form3.tech>