### PR TITLE
Cleanup duplicate "Overview" lines in GoDoc

### DIFF
--- a/surveyor/collector_statz.go
+++ b/surveyor/collector_statz.go
@@ -11,7 +11,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package surveyor is used to garner data from a NATS deployment for Prometheus
 package surveyor
 
 import (

--- a/surveyor/surveyor_test.go
+++ b/surveyor/surveyor_test.go
@@ -11,7 +11,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package surveyor is used to garner data from a NATS deployment for Prometheus
 package surveyor
 
 import (


### PR DESCRIPTION
GoDoc appends a package's doc item from all files in the package.

Example:
https://pkg.go.dev/github.com/nats-io/nats-surveyor@v0.1.1/surveyor#pkg-overview

Signed-off-by: Ben Werthmann <ben@synadia.com>