### PR TITLE
[FIX BUILD] Make go vet happy

### DIFF
--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -32,6 +32,7 @@ jobs:
         run: |
           export GOPATH="$RUNNER_WORKSPACE"
 
+          go mod tidy
           go vet ./...
           $(go env GOPATH)/bin/golangci-lint run \
              --no-config --exclude-use-default=false --max-same-issues=0 \


### PR DESCRIPTION
Noticed the build was broken in #56 see job https://github.com/nats-io/nats-surveyor/runs/4436497974?check_suite_focus=true#step:5:39

copy of the logs:
```
+ go vet ./...
go: downloading github.com/nats-io/jsm.go v0.0.23
go: downloading github.com/nats-io/nats-server/v2 v2.2.6
go: downloading github.com/nats-io/nats.go v1.11.0
go: downloading github.com/nats-io/nuid v1.0.1
go: downloading github.com/nats-io/nkeys v0.3.0
go: downloading github.com/minio/highwayhash v1.0.2
go: downloading github.com/nats-io/jwt v1.2.2
go: downloading golang.org/x/time v0.0.0-20210220033141-f8bda1e9f3ba
go: downloading github.com/nats-io/jwt/v2 v2.0.2
go: downloading github.com/dustin/go-humanize v1.0.0
Error: ../../../../pkg/mod/github.com/nats-io/jsm.go@v0.0.23/snapshots.go:30:2: missing go.sum entry for module providing package github.com/klauspost/compress/s2 (imported by github.com/nats-io/jsm.go); to add:
	go get github.com/nats-io/jsm.go@v0.0.23
Error: ../../../../pkg/mod/github.com/nats-io/nats-server/v2@v2.2.6/server/auth.go:33:2: missing go.sum entry for module providing package golang.org/x/crypto/bcrypt (imported by github.com/nats-io/nats-surveyor/surveyor); to add:
	go get github.com/nats-io/nats-surveyor/surveyor
Error: ../../../../pkg/mod/github.com/nats-io/nkeys@v0.3.0/keypair.go:21:2: missing go.sum entry for module providing package golang.org/x/crypto/ed25519 (imported by github.com/nats-io/nkeys); to add:
	go get github.com/nats-io/nkeys@v0.3.0
Error: Process completed with exit code 1.
```

Suggested by RI in https://github.com/nats-io/nats-surveyor/pull/56#issuecomment-988152630

Co-authored-by: R.I.Pienaar <rip@devco.net>
Signed-off-by: Ben Werthmann <ben@synadia.com>