### PR TITLE
Update dependencies.md too, plus instructions

### DIFF
--- a/dependencies.md
+++ b/dependencies.md
@@ -2,47 +2,50 @@
 
 This file lists the dependencies used in this repository.
 
-| Dependency | License |
-|-|-|
-| github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751 | BSD 3-Clause "New" or "Revised" License |
-| github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4 | MIT |
-| github.com/beorn7/perks v1.0.1 | MIT |
-| github.com/cespare/xxhash/v2 v2.1.0 | MIT |
-| github.com/davecgh/go-spew v1.1.1 | ISC License |
-| github.com/go-kit/kit v0.9.0 | MIT |
-| github.com/go-logfmt/logfmt v0.4.0 | MIT |
-| github.com/go-stack/stack v1.8.0 | MIT |
-| github.com/gogo/protobuf v1.1.1 | BSD 3-Clause "New" or "Revised" License |
-| github.com/golang/protobuf v1.3.2 | BSD 3-Clause "New" or "Revised" License |
-| github.com/google/go-cmp v0.3.0 | BSD 3-Clause "New" or "Revised" License |
-| github.com/google/gofuzz v1.0.0 | Apache License 2.0 |
-| github.com/json-iterator/go v1.1.7 | MIT |
-| github.com/julienschmidt/httprouter v1.2.0 | BSD 3-Clause "New" or "Revised" License |
-| github.com/konsorten/go-windows-terminal-sequences v1.0.1 | MIT |
-| github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515 | MIT-Like |
-| github.com/matttproud/golang_protobuf_extensions v1.0.1 | Apache License 2.0 |
-| github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd | Apache License 2.0 |
-| github.com/modern-go/reflect2 v1.0.1 | Apache License 2.0 |
-| github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223 | Apache License 2.0 |
-| github.com/nats-io/jwt v0.3.0 | Apache License 2.0 |
-| github.com/nats-io/nats-server/v2 v2.1.1-0.20191017173141-daabd4dfde22 | Apache License 2.0 |
-| github.com/nats-io/nats.go v1.8.1 | Apache License 2.0 |
-| github.com/nats-io/nkeys v0.1.0 | Apache License 2.0 |
-| github.com/nats-io/nuid v1.0.1 | Apache License 2.0 |
-| github.com/pkg/errors v0.8.1 | Apache License 2.0 |
-| github.com/pmezard/go-difflib v1.0.0 | BSD 3-Clause "New" or "Revised" License |
-| github.com/prometheus/client_golang v1.2.1 | Apache 2.0 License |
-| github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4 | Apache 2.0 License |
-| github.com/prometheus/common v0.7.0 | Apache 2.0 License |
-| github.com/prometheus/procfs v0.0.5 | Apache 2.0 License |
-| github.com/sirupsen/logrus v1.4.2 | MIT |
-| github.com/stretchr/objx v0.1.1 | MIT |
-| github.com/stretchr/testify v1.3.0 | MIT |
-| golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550 | BSD 3-Clause "New" or "Revised" License |
-| golang.org/x/net v0.0.0-20190613194153-d28f0bde5980 | BSD 3-Clause "New" or "Revised" License |
-| golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4 | BSD 3-Clause "New" or "Revised" License |
-| golang.org/x/sys v0.0.0-20191010194322-b09406accb47 | BSD 3-Clause "New" or "Revised" License |
-| golang.org/x/text v0.3.0 | BSD 3-Clause "New" or "Revised" License |
-| gopkg.in/alecthomas/kingpin.v2 v2.2.6 | MIT |
-| gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 | BSD 2-Clause "Simplified" License |
-| gopkg.in/yaml.v2 v2.2.2 | Apache 2.0 License |
+We restrict it to the dependencies pulled into the actual binary.
+
+Update instructions
+
+```sh
+go install github.com/mitchellh/golicense@latest
+
+go build
+export GITHUB_TOKEN='...'
+golicense nats-surveyor
+golicense -plain nats-surveyor | sort > licenses
+
+go list -f '{{with .Module}}{{if .Version}}{{.Path}}{{"\t"}}{{.Version}}{{end}}{{end}}' all | sort -u > versions
+
+wc -l versions licenses
+
+paste versions licenses | awk '{if (index($1,$3) == 1) {print "| " $3 " | " $2 " | " $4 " |"} else {print "MISMATCH"}}'
+
+rm versions licenses
+```
+
+## Dependency Table
+
+| Dependency | Version | License |
+|-|-|-|
+| github.com/beorn7/perks | v1.0.1 | MIT |
+| github.com/cespare/xxhash | v2.1.2 | MIT |
+| github.com/dustin/go-humanize | v1.0.0 | MIT |
+| github.com/golang/protobuf | v1.5.2 | BSD |
+| github.com/klauspost/compress | v1.14.2 | MIT |
+| github.com/matttproud/golang_protobuf_extensions | v1.0.1 | Apache |
+| github.com/minio/highwayhash | v1.0.2 | Apache |
+| github.com/nats-io/jsm.go | v0.0.27 | Apache |
+| github.com/nats-io/jwt | v2.2.1-0.20220113022732-58e87895b296 | Apache |
+| github.com/nats-io/nats.go | v1.13.1-0.20220121202836-972a071d373d | Apache |
+| github.com/nats-io/nats-server | v2.7.1 | Apache |
+| github.com/nats-io/nkeys | v0.3.0 | Apache |
+| github.com/nats-io/nuid | v1.0.1 | Apache |
+| github.com/prometheus/client_golang | v1.12.0 | Apache |
+| github.com/prometheus/client_model | v0.2.0 | Apache |
+| github.com/prometheus/common | v0.32.1 | Apache |
+| github.com/prometheus/procfs | v0.7.3 | Apache |
+| golang.org/x/crypto | v0.0.0-20220126234351-aa10faf2a1f8 | BSD |
+| golang.org/x/sys | v0.0.0-20220114195835-da31bd327af9 | BSD |
+| golang.org/x/time | v0.0.0-20211116232009-f0f3c7e86c11 | BSD |
+| google.golang.org/protobuf | v1.27.1 | BSD |
+

--- a/dependencies.md
+++ b/dependencies.md
@@ -11,7 +11,6 @@ go install github.com/mitchellh/golicense@latest
 
 go build
 export GITHUB_TOKEN='...'
-golicense nats-surveyor
 golicense -plain nats-surveyor | sort > licenses
 
 go list -f '{{with .Module}}{{if .Version}}{{.Path}}{{"\t"}}{{.Version}}{{end}}{{end}}' all | sort -u > versions


### PR DESCRIPTION
The dependencies list was overly inclusive; restrict it to just those items found by go when looking at what's actually used for a build.

Show how to automate the steps to rebuild the table.  Make the table three columns (software, version, license; moves version to its own column).

Licenses as emitted by golicense v0.2.0.
