### PR TITLE
Use go install instead of go get

### DIFF
--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -23,8 +23,8 @@ jobs:
           GO111MODULE: "on"
         run: |
           export GOPATH="$RUNNER_WORKSPACE"
-          go get -v github.com/wadey/gocovmerge
-          go get -v github.com/golangci/golangci-lint/cmd/golangci-lint
+          cd /tmp && go install -v github.com/wadey/gocovmerge@latest
+          cd /tmp && go install -v github.com/golangci/golangci-lint/cmd/golangci-lint@latest
       - name: Lint
         shell: bash --noprofile --norc -x -eo pipefail {0}
         env:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -21,8 +21,8 @@ jobs:
         GO111MODULE: 'on'
       run: |
         export GOPATH="$RUNNER_WORKSPACE"
-        go get -v github.com/wadey/gocovmerge
-        go get -v github.com/golangci/golangci-lint/cmd/golangci-lint
+        cd /tmp && go install -v github.com/wadey/gocovmerge@latest
+        cd /tmp && go install -v github.com/golangci/golangci-lint/cmd/golangci-lint@latest
     - name: Release
       shell: bash --noprofile --norc -x -eo pipefail {0}
       env:


### PR DESCRIPTION
`go get` for installing binaries is deprecated. https://go.dev/doc/go-get-install-deprecation