### PR TITLE
Set version to v0.2.3-0 to align with go psudoversion

### DIFF
--- a/main.go
+++ b/main.go
@@ -26,7 +26,7 @@ import (
 	"github.com/nats-io/nats-surveyor/surveyor"
 )
 
-var version = "v0.2.2"
+var version = "v0.2.3-0"
 
 func main() {
 	var printVersion bool


### PR DESCRIPTION
Keep version in sync with go mod psudo version.

From outside of your nats-surveyor workspace, perform a 'go install':

(else; you'll just see 'devel')

```
$ CGO_ENABLED=0 go install -trimpath -x -v github.com/nats-io/nats-surveyor@master
```
```
$ go version -m ./bin/nats-surveyor
./bin/nats-surveyor: go1.17.7
	path	github.com/nats-io/nats-surveyor
	mod	github.com/nats-io/nats-surveyor	v0.2.3-0.20220216132415-52a3fca390ca	h1:JKWGWLVdqjJFykSeT3LJfYocOxOvmLOhGcETvf7AI8U=
	dep	github.com/beorn7/perks	v1.0.1	h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
	dep	github.com/cespare/xxhash/v2	v2.1.2	h1:YRXhKfTDauu4ajMg1TPgFO5jnlC2HCbmLXMcTG5cbYE=
	dep	github.com/dustin/go-humanize	v1.0.0	h1:VSnTsYCnlFHaM2/igO1h6X3HA71jcobQuxemgkq4zYo=
	dep	github.com/golang/protobuf	v1.5.2	h1:ROPKBNFfQgOUMifHyP+KYbvpjbdoFNs+aK7DXlji0Tw=
	dep	github.com/klauspost/compress	v1.14.2	h1:S0OHlFk/Gbon/yauFJ4FfJJF5V0fc5HbBTJazi28pRw=
	dep	github.com/matttproud/golang_protobuf_extensions	v1.0.1	h1:4hp9jkHxhMHkqkrB3Ix0jegS5sx/RkqARlsWZ6pIwiU=
	dep	github.com/minio/highwayhash	v1.0.2	h1:Aak5U0nElisjDCfPSG79Tgzkn2gl66NxOMspRrKnA/g=
	dep	github.com/nats-io/jsm.go	v0.0.27	h1:AncMtVmFLFN4/+BkbPGJ2Y1EwpqImyVOMKFehuPDpOY=
	dep	github.com/nats-io/jwt/v2	v2.2.1-0.20220113022732-58e87895b296	h1:vU9tpM3apjYlLLeY23zRWJ9Zktr5jp+mloR942LEOpY=
	dep	github.com/nats-io/nats-server/v2	v2.7.2	h1:+LEN8m0+jdCkiGc884WnDuxR+qj80/5arj+szKuRpRI=
	dep	github.com/nats-io/nats.go	v1.13.1-0.20220121202836-972a071d373d	h1:GRSmEJutHkdoxKsRypP575IIdoXe7Bm6yHQF6GcDBnA=
	dep	github.com/nats-io/nkeys	v0.3.0	h1:cgM5tL53EvYRU+2YLXIK0G2mJtK12Ft9oeooSZMA2G8=
	dep	github.com/nats-io/nuid	v1.0.1	h1:5iA8DT8V7q8WK2EScv2padNa/rTESc1KdnPw4TC2paw=
	dep	github.com/prometheus/client_golang	v1.12.1	h1:ZiaPsmm9uiBeaSMRznKsCDNtPCS0T3JVDGF+06gjBzk=
	dep	github.com/prometheus/client_model	v0.2.0	h1:uq5h0d+GuxiXLJLNABMgp2qUWDPiLvgCzz2dUR+/W/M=
	dep	github.com/prometheus/common	v0.32.1	h1:hWIdL3N2HoUx3B8j3YN9mWor0qhY/NlEKZEaXxuIRh4=
	dep	github.com/prometheus/procfs	v0.7.3	h1:4jVXhlkAyzOScmCkXBTOLRLTz8EeU+eyjrwB/EPq0VU=
	dep	golang.org/x/crypto	v0.0.0-20220214200702-86341886e292	h1:f+lwQ+GtmgoY+A2YaQxlSOnDjXcQ7ZRLWOHbC6HtRqE=
	dep	golang.org/x/sys	v0.0.0-20220209214540-3681064d5158	h1:rm+CHSpPEEW2IsXUib1ThaHIjuBVZjxNgSKmBLFfD4c=
	dep	golang.org/x/time	v0.0.0-20220210224613-90d013bbcef8	h1:vVKdlvoWBphwdxWKrFZEuM0kGgGLxUOYcY4U/2Vjg44=
	dep	google.golang.org/protobuf	v1.27.1	h1:SnqbnDw1V7RiZcXPx5MEeqPv2s79L9i7BJUlG/+RurQ=
```

Before:

```
$ CGO_ENABLED=0 go install -trimpath github.com/nats-io/nats-surveyor@master
nats-surveyor v0.2.2
```

After:

```
$ CGO_ENABLED=0 go run -trimpath . --version
nats-surveyor v0.2.3-0
```