### PR TITLE
Publish per account metrics

### DIFF
--- a/main.go
+++ b/main.go
@@ -57,6 +57,7 @@ func main() {
 	flag.StringVar(&opts.Prefix, "prefix", "", "Replace the default prefix for all the metrics.")
 	flag.StringVar(&opts.ObservationConfigDir, "observe", "", "Listen for observation statistics based on config files in a directory.")
 	flag.StringVar(&opts.JetStreamConfigDir, "jetstream", "", "Listen for JetStream Advisories based on config files in a directory.")
+	flag.BoolVar(&opts.Accounts, "accounts", false, "Export per account metrics")
 	flag.Parse()
 
 	if printVersion {

--- a/surveyor/surveyor.go
+++ b/surveyor/surveyor.go
@@ -72,6 +72,7 @@ type Options struct {
 	Prefix               string // TODO
 	ObservationConfigDir string
 	JetStreamConfigDir   string
+	Accounts             bool
 }
 
 // GetDefaultOptions returns the default set of options
@@ -182,8 +183,13 @@ func (s *Surveyor) createStatszCollector() error {
 		return nil
 	}
 
+	if !s.opts.Accounts {
+		log.Printf("Skipping per account exports")
+	}
+
 	s.Lock()
-	s.statzC = NewStatzCollector(s.nc, s.opts.ExpectedServers, s.opts.PollTimeout)
+	s.statzC = NewStatzCollector(s.nc, s.opts.ExpectedServers, s.opts.PollTimeout,
+		s.opts.Accounts)
 	s.Unlock()
 
 	err := prometheus.Register(s.statzC)


### PR DESCRIPTION
This change adds an option to Surveyor that publishes account level metrics using the system account. You can enable this feature by passing `-accounts` to `nats-surveyor`.

Here's what the data looks like in Grafana:
![image](https://user-images.githubusercontent.com/107430465/176787193-8cd733d7-42d6-4457-9ea8-d707593b96f7.png)
