### PR TITLE
fix: jetstream and observe flags

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -67,8 +67,8 @@ func rootCmdArgs(args []string) []string {
 		"-http_pass":       "--http-pass",
 		"--http_pass":      "--http-pass",
 		"-prefix":          "--prefix",
-		"-observe":         "-observe",
-		"-jetstream":       "-jetstream",
+		"-observe":         "--observe",
+		"-jetstream":       "--jetstream",
 	}
 	newArgs := make([]string, 0)
 

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -30,8 +30,8 @@ func TestRootCmdArgs(t *testing.T) {
 		},
 		{
 			"compound",
-			[]string{"-http_tlscert", "a", "--http_tlskey", "b", "-http_tlscacert=c", "--", "-version"},
-			"--http-tlscert a --http-tlskey b --http-tlscacert=c -- -version",
+			[]string{"-http_tlscert", "a", "--http_tlskey", "b", "-http_tlscacert=c", "-jetstream=/jetstream", "-observe=/observe", "--", "-version"},
+			"--http-tlscert a --http-tlskey b --http-tlscacert=c --jetstream=/jetstream --observe=/observe -- -version",
 		},
 	}
 


### PR DESCRIPTION
fixes: https://github.com/nats-io/nats-surveyor/issues/91

Using 0.3.0 with helm chart 0.13.2 or earlier causes a crash because there is no short hand `-j`.

This is caused by not converting `-jetstream` flag to `--jetstream`