### PR TITLE
Use logrus for logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Flags:
       --http-tlskey string      Private key for server certificate (used with HTTPS).
       --http-user string        Enable basic auth and set user name for HTTP scrapes.
       --jetstream string        Listen for JetStream Advisories based on config files in a directory.
-      --log-level string        Log level, one of: trace|debug|info|warn|error|fatal|panic (default: info)
+      --log-level string        Log level, one of: trace|debug|info|warn|error|fatal|panic (default "info")
       --nkey string             Nkey Seed File
       --observe string          Listen for observation statistics based on config files in a directory.
       --password string         NATS user password
@@ -59,22 +59,29 @@ At this time, NATS 2.0 System credentials are required for meaningful usage.
 
 ### Config Files
 
-Surveyor uses Viper to read configs so it will support all file types that Viper supports (JSON, TOML, YAML, HCL, envfile, and Java properties)
+Surveyor uses Viper to read configs, so it will support all file types that Viper supports (JSON, TOML, YAML, HCL, envfile, and Java properties)
 
 To use a config file pass the `--config` flag. The defaults are `/etc/nats-surveyor/nats-surveyor[.ext]` and `./nats-surveyor[.ext]` with one of the supported extensions.
 
-The config is simple, just set each flag in the config file. For example:
+The config is simple, just set each flag in the config file. Example `nats-surveyor.yaml`:
 
-```
+```yaml
 servers: nats://127.0.0.1:4222
 accounts: true
+log-level: debug
 ```
 
 ### Environment Variables
 
-Environment variables are also taken into account. Any environment variable that is prefixed with `NATS_SURVEYOR` will be read. 
+Environment variables are also taken into account. Any environment variable that is prefixed with `NATS_SURVEYOR_` will be read.
 
-For example to enable accounts set `NATS_SURVEYOR_ACCOUNTS=true`
+Each flag has a matching environment variable, flag names should be converted to uppercase and dashes replaced with underscores.  Example: 
+
+```
+NATS_SURVEYOR_SERVERS=nats://127.0.0.1:4222
+NATS_SURVEYOR_ACCOUNTS=true
+NATS_SURVEYOR_LOG_LEVEL=debug
+```
 
 ## Metrics
 

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Flags:
       --http-tlskey string      Private key for server certificate (used with HTTPS).
       --http-user string        Enable basic auth and set user name for HTTP scrapes.
       --jetstream string        Listen for JetStream Advisories based on config files in a directory.
+      --log-level string        Log level, one of: trace|debug|info|warn|error|fatal|panic (default: info)
       --nkey string             Nkey Seed File
       --observe string          Listen for observation statistics based on config files in a directory.
       --password string         NATS user password
@@ -38,7 +39,7 @@ Flags:
       --prefix string           Replace the default prefix for all the metrics.
   -s, --servers string          NATS Cluster url(s) (default "nats://127.0.0.1:4222")
       --timeout duration        Polling timeout (default 3s)
-      --tlscacert string        Client certificate CA on NATS connecctions.
+      --tlscacert string        Client certificate CA on NATS connections.
       --tlscert string          Client certificate file for NATS connections.
       --tlskey string           Client private key for NATS connections.
       --user string             NATS user name or token

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -219,7 +219,7 @@ func init() {
 	_ = viper.BindPFlag("accounts", rootCmd.Flags().Lookup("accounts"))
 
 	// log-level
-	rootCmd.Flags().String("log-level", "", "Log level, must be trace, debug, info, warn, error, fatal, or panic.  Defaults to info")
+	rootCmd.Flags().String("log-level", "", "Log level, one of: trace|debug|info|warn|error|fatal|panic (default: info)")
 	_ = viper.BindPFlag("log-level", rootCmd.Flags().Lookup("log-level"))
 
 	cobra.OnInitialize(initConfig)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -37,7 +37,7 @@ var (
 		Use:     "nats-surveyor",
 		Short:   "Prometheus exporter for NATS",
 		RunE:    run,
-		Version: "v0.3.1",
+		Version: "v0.4.0",
 	}
 	logger = logrus.New()
 )

--- a/go.mod
+++ b/go.mod
@@ -3,11 +3,13 @@ module github.com/nats-io/nats-surveyor
 go 1.18
 
 require (
+	github.com/antonfisher/nested-logrus-formatter v1.3.1
 	github.com/nats-io/jsm.go v0.0.33
 	github.com/nats-io/nats-server/v2 v2.8.4
 	github.com/nats-io/nats.go v1.16.0
 	github.com/nats-io/nuid v1.0.1
 	github.com/prometheus/client_golang v1.12.1
+	github.com/sirupsen/logrus v1.9.0
 	github.com/spf13/cobra v1.5.0
 	github.com/spf13/viper v1.12.0
 	golang.org/x/crypto v0.0.0-20220411220226-7b82a4e95df4
@@ -38,7 +40,7 @@ require (
 	github.com/spf13/jwalterweatherman v1.1.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/subosito/gotenv v1.3.0 // indirect
-	golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a // indirect
+	golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8 // indirect
 	golang.org/x/text v0.3.7 // indirect
 	golang.org/x/time v0.0.0-20220210224613-90d013bbcef8 // indirect
 	google.golang.org/protobuf v1.28.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -43,6 +43,8 @@ github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuy
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d/go.mod h1:rBZYJk541a8SKzHPHnH3zbiI+7dagKZ0cgpgrD7Fyho=
+github.com/antonfisher/nested-logrus-formatter v1.3.1 h1:NFJIr+pzwv5QLHTPyKz9UMEoHck02Q9L0FP13b/xSbQ=
+github.com/antonfisher/nested-logrus-formatter v1.3.1/go.mod h1:6WTfyWFkBc9+zyBaKIqRrg/KwMqBbodBjgbHjDz7zjA=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
@@ -238,6 +240,8 @@ github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQD
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
 github.com/sirupsen/logrus v1.6.0/go.mod h1:7uNnSEd1DgxDLC74fIahvMZmmYsHGZGEOFrfsX/uA88=
+github.com/sirupsen/logrus v1.9.0 h1:trlNQbNUG3OdDrDil03MCb1H2o9nJ1x4/5LYw7byDE0=
+github.com/sirupsen/logrus v1.9.0/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
 github.com/spf13/afero v1.8.2 h1:xehSyVa0YnHWsJ49JFljMpg1HX19V6NDZ1fkm1Xznbo=
 github.com/spf13/afero v1.8.2/go.mod h1:CtAatgMJh6bJEIs48Ay/FOnkljP3WeGUG0MC1RfAqwo=
 github.com/spf13/cast v1.5.0 h1:rj3WzYc11XZaIZMPKmwP96zkFEnnAmV8s6XbB2aY32w=
@@ -415,8 +419,8 @@ golang.org/x/sys v0.0.0-20210603081109-ebe580a85c40/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220114195835-da31bd327af9/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220412211240-33da011f77ad/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a h1:dGzPydgVsqGcTRVwiLJ1jVbufYwmzD3LfVPLKsKg+0k=
-golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8 h1:0A+M6Uqn+Eje4kHMK80dtF3JCXC4ykBgQG4Fe06QRhQ=
+golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=


### PR DESCRIPTION
- changes logging to use logrus
- classifies each current log message
- adds `log-level` command line arg
- if started from command line, format uses [nested-logrus-formatter](https://github.com/antonfisher/nested-logrus-formatter) with RFC3339 date format, example:
  ```
  2022-08-17T14:36:56-04:00 [INFO] test info
  2022-08-17T14:36:56-04:00 [WARN] test warn
  2022-08-17T14:36:56-04:00 [ERRO] test error
  ```