### PR TITLE
Add ConstLabels option

### DIFF
--- a/surveyor/jetstream_advisories.go
+++ b/surveyor/jetstream_advisories.go
@@ -61,118 +61,139 @@ type JSAdvisoryMetrics struct {
 	jsConsumerDeliveryNAK   *prometheus.CounterVec
 }
 
-func NewJetStreamAdvisoryMetrics(registry *prometheus.Registry) *JSAdvisoryMetrics {
+func NewJetStreamAdvisoryMetrics(registry *prometheus.Registry, constLabels prometheus.Labels) *JSAdvisoryMetrics {
 	metrics := &JSAdvisoryMetrics{
 		// API Audit
 		jsAPIAuditCtr: prometheus.NewCounterVec(prometheus.CounterOpts{
-			Name: prometheus.BuildFQName("nats", "jetstream", "api_audit"),
-			Help: "JetStream API access audit events",
+			Name:        prometheus.BuildFQName("nats", "jetstream", "api_audit"),
+			Help:        "JetStream API access audit events",
+			ConstLabels: constLabels,
 		}, []string{"subject", "account"}),
 
 		// Delivery Exceeded
 		jsDeliveryExceededCtr: prometheus.NewCounterVec(prometheus.CounterOpts{
-			Name: prometheus.BuildFQName("nats", "jetstream", "delivery_exceeded_count"),
-			Help: "Advisories about JetStream Consumer Delivery Exceeded events",
+			Name:        prometheus.BuildFQName("nats", "jetstream", "delivery_exceeded_count"),
+			Help:        "Advisories about JetStream Consumer Delivery Exceeded events",
+			ConstLabels: constLabels,
 		}, []string{"account", "stream", "consumer"}),
 
 		jsDeliveryTerminatedCtr: prometheus.NewCounterVec(prometheus.CounterOpts{
-			Name: prometheus.BuildFQName("nats", "jetstream", "delivery_terminated_count"),
-			Help: "Advisories about JetStream Consumer Delivery Terminated events",
+			Name:        prometheus.BuildFQName("nats", "jetstream", "delivery_terminated_count"),
+			Help:        "Advisories about JetStream Consumer Delivery Terminated events",
+			ConstLabels: constLabels,
 		}, []string{"account", "stream", "consumer"}),
 
 		// Ack Samples
 		jsAckMetricDelay: prometheus.NewHistogramVec(prometheus.HistogramOpts{
-			Name: prometheus.BuildFQName("nats", "jetstream", "acknowledgement_duration"),
-			Help: "How long an Acknowledged message took to be Acknowledged",
+			Name:        prometheus.BuildFQName("nats", "jetstream", "acknowledgement_duration"),
+			Help:        "How long an Acknowledged message took to be Acknowledged",
+			ConstLabels: constLabels,
 		}, []string{"account", "stream", "consumer"}),
 
 		jsAckMetricDeliveries: prometheus.NewCounterVec(prometheus.CounterOpts{
-			Name: prometheus.BuildFQName("nats", "jetstream", "acknowledgement_deliveries"),
-			Help: "How many times messages took to be delivered and Acknowledged",
+			Name:        prometheus.BuildFQName("nats", "jetstream", "acknowledgement_deliveries"),
+			Help:        "How many times messages took to be delivered and Acknowledged",
+			ConstLabels: constLabels,
 		}, []string{"account", "stream", "consumer"}),
 
 		// Misc
 		jsAdvisoriesGauge: prometheus.NewGauge(prometheus.GaugeOpts{
-			Name: prometheus.BuildFQName("nats", "jetstream", "advisory_count"),
-			Help: "Number of JetStream Advisory listeners that are running",
+			Name:        prometheus.BuildFQName("nats", "jetstream", "advisory_count"),
+			Help:        "Number of JetStream Advisory listeners that are running",
+			ConstLabels: constLabels,
 		}),
 
 		jsUnknownAdvisoryCtr: prometheus.NewCounterVec(prometheus.CounterOpts{
-			Name: prometheus.BuildFQName("nats", "jetstream", "unknown_advisories"),
-			Help: "Unsupported JetStream Advisory types received",
+			Name:        prometheus.BuildFQName("nats", "jetstream", "unknown_advisories"),
+			Help:        "Unsupported JetStream Advisory types received",
+			ConstLabels: constLabels,
 		}, []string{"schema", "account"}),
 
 		jsTotalAdvisoryCtr: prometheus.NewCounterVec(prometheus.CounterOpts{
-			Name: prometheus.BuildFQName("nats", "jetstream", "total_advisories"),
-			Help: "Total JetStream Advisories handled",
+			Name:        prometheus.BuildFQName("nats", "jetstream", "total_advisories"),
+			Help:        "Total JetStream Advisories handled",
+			ConstLabels: constLabels,
 		}, []string{"account"}),
 
 		jsAdvisoryParseErrorCtr: prometheus.NewCounterVec(prometheus.CounterOpts{
-			Name: prometheus.BuildFQName("nats", "jetstream", "advisory_parse_errors"),
-			Help: "Number of advisories that could not be parsed",
+			Name:        prometheus.BuildFQName("nats", "jetstream", "advisory_parse_errors"),
+			Help:        "Number of advisories that could not be parsed",
+			ConstLabels: constLabels,
 		}, []string{"account"}),
 
 		// Stream and Consumer actions
 		jsConsumerActionCtr: prometheus.NewCounterVec(prometheus.CounterOpts{
-			Name: prometheus.BuildFQName("nats", "jetstream", "consumer_actions"),
-			Help: "Actions performed on consumers",
+			Name:        prometheus.BuildFQName("nats", "jetstream", "consumer_actions"),
+			Help:        "Actions performed on consumers",
+			ConstLabels: constLabels,
 		}, []string{"account", "stream", "action"}),
 
 		jsStreamActionCtr: prometheus.NewCounterVec(prometheus.CounterOpts{
-			Name: prometheus.BuildFQName("nats", "jetstream", "stream_actions"),
-			Help: "Actions performed on streams",
+			Name:        prometheus.BuildFQName("nats", "jetstream", "stream_actions"),
+			Help:        "Actions performed on streams",
+			ConstLabels: constLabels,
 		}, []string{"account", "stream", "action"}),
 
 		// Snapshot create
 		jsSnapshotSizeCtr: prometheus.NewCounterVec(prometheus.CounterOpts{
-			Name: prometheus.BuildFQName("nats", "jetstream", "snapshot_size_bytes"),
-			Help: "The size of snapshots being created",
+			Name:        prometheus.BuildFQName("nats", "jetstream", "snapshot_size_bytes"),
+			Help:        "The size of snapshots being created",
+			ConstLabels: constLabels,
 		}, []string{"account", "stream"}),
 
 		jsSnapthotDuration: prometheus.NewHistogramVec(prometheus.HistogramOpts{
-			Name: prometheus.BuildFQName("nats", "jetstream", "snapshot_duration"),
-			Help: "How long a snapshot takes to be processed",
+			Name:        prometheus.BuildFQName("nats", "jetstream", "snapshot_duration"),
+			Help:        "How long a snapshot takes to be processed",
+			ConstLabels: constLabels,
 		}, []string{"account", "stream"}),
 
 		// Restore
 		jsRestoreCreatedCtr: prometheus.NewCounterVec(prometheus.CounterOpts{
-			Name: prometheus.BuildFQName("nats", "jetstream", "restore_created_count"),
-			Help: "How many restore operations were started",
+			Name:        prometheus.BuildFQName("nats", "jetstream", "restore_created_count"),
+			Help:        "How many restore operations were started",
+			ConstLabels: constLabels,
 		}, []string{"account", "stream"}),
 
 		jsRestoreSizeCtr: prometheus.NewCounterVec(prometheus.CounterOpts{
-			Name: prometheus.BuildFQName("nats", "jetstream", "restore_size_bytes"),
-			Help: "The size of restores that was completed",
+			Name:        prometheus.BuildFQName("nats", "jetstream", "restore_size_bytes"),
+			Help:        "The size of restores that was completed",
+			ConstLabels: constLabels,
 		}, []string{"account", "stream"}),
 
 		jsRestoreDuration: prometheus.NewHistogramVec(prometheus.HistogramOpts{
-			Name: prometheus.BuildFQName("nats", "jetstream", "restore_duration"),
-			Help: "How long a restore took to be processed",
+			Name:        prometheus.BuildFQName("nats", "jetstream", "restore_duration"),
+			Help:        "How long a restore took to be processed",
+			ConstLabels: constLabels,
 		}, []string{"account", "stream"}),
 
 		jsConsumerLeaderElected: prometheus.NewCounterVec(prometheus.CounterOpts{
-			Name: prometheus.BuildFQName("nats", "jetstream", "consumer_leader_elected"),
-			Help: "How many times leader elections were done for consumers",
+			Name:        prometheus.BuildFQName("nats", "jetstream", "consumer_leader_elected"),
+			Help:        "How many times leader elections were done for consumers",
+			ConstLabels: constLabels,
 		}, []string{"account", "stream"}),
 
 		jsConsumerQuorumLost: prometheus.NewCounterVec(prometheus.CounterOpts{
-			Name: prometheus.BuildFQName("nats", "jetstream", "consumer_quorum_lost"),
-			Help: "How many times a consumer lost quorum leading to new leader elections",
+			Name:        prometheus.BuildFQName("nats", "jetstream", "consumer_quorum_lost"),
+			Help:        "How many times a consumer lost quorum leading to new leader elections",
+			ConstLabels: constLabels,
 		}, []string{"account", "stream"}),
 
 		jsStreamLeaderElected: prometheus.NewCounterVec(prometheus.CounterOpts{
-			Name: prometheus.BuildFQName("nats", "jetstream", "stream_leader_elected"),
-			Help: "How many times leader elections were done for streams",
+			Name:        prometheus.BuildFQName("nats", "jetstream", "stream_leader_elected"),
+			Help:        "How many times leader elections were done for streams",
+			ConstLabels: constLabels,
 		}, []string{"account", "stream"}),
 
 		jsStreamQuorumLost: prometheus.NewCounterVec(prometheus.CounterOpts{
-			Name: prometheus.BuildFQName("nats", "jetstream", "stream_quorum_lost"),
-			Help: "How many times a stream lost quorum leading to new leader elections",
+			Name:        prometheus.BuildFQName("nats", "jetstream", "stream_quorum_lost"),
+			Help:        "How many times a stream lost quorum leading to new leader elections",
+			ConstLabels: constLabels,
 		}, []string{"account", "stream"}),
 
 		jsConsumerDeliveryNAK: prometheus.NewCounterVec(prometheus.CounterOpts{
-			Name: prometheus.BuildFQName("nats", "jetstream", "consumer_nak"),
-			Help: "How many times a consumer sent a NAK",
+			Name:        prometheus.BuildFQName("nats", "jetstream", "consumer_nak"),
+			Help:        "How many times a consumer sent a NAK",
+			ConstLabels: constLabels,
 		}, []string{"account", "stream", "consumer"}),
 	}
 

--- a/surveyor/jetstream_advisories_test.go
+++ b/surveyor/jetstream_advisories_test.go
@@ -18,7 +18,7 @@ func TestJetStream_Load(t *testing.T) {
 
 	opt := GetDefaultOptions()
 	opt.URLs = js.ClientURL()
-	metrics := NewJetStreamAdvisoryMetrics(prometheus.NewRegistry())
+	metrics := NewJetStreamAdvisoryMetrics(prometheus.NewRegistry(), nil)
 	reconnectCtr := prometheus.NewCounterVec(prometheus.CounterOpts{
 		Name: prometheus.BuildFQName("nats", "survey", "nats_reconnects"),
 		Help: "Number of times the surveyor reconnected to the NATS cluster",
@@ -64,7 +64,7 @@ func TestJetStream_Handle(t *testing.T) {
 
 	opt := GetDefaultOptions()
 	opt.URLs = js.ClientURL()
-	metrics := NewJetStreamAdvisoryMetrics(prometheus.NewRegistry())
+	metrics := NewJetStreamAdvisoryMetrics(prometheus.NewRegistry(), nil)
 	reconnectCtr := prometheus.NewCounterVec(prometheus.CounterOpts{
 		Name: prometheus.BuildFQName("nats", "survey", "nats_reconnects"),
 		Help: "Number of times the surveyor reconnected to the NATS cluster",

--- a/surveyor/observation.go
+++ b/surveyor/observation.go
@@ -40,51 +40,60 @@ type ServiceObsMetrics struct {
 	systemRTT                   *prometheus.HistogramVec
 }
 
-func NewServiceObservationMetrics(registry *prometheus.Registry) *ServiceObsMetrics {
+func NewServiceObservationMetrics(registry *prometheus.Registry, constLabels prometheus.Labels) *ServiceObsMetrics {
 	metrics := &ServiceObsMetrics{
 		observationsGauge: prometheus.NewGauge(prometheus.GaugeOpts{
-			Name: prometheus.BuildFQName("nats", "latency", "observations_count"),
-			Help: "Number of Service Latency listeners that are running",
+			Name:        prometheus.BuildFQName("nats", "latency", "observations_count"),
+			Help:        "Number of Service Latency listeners that are running",
+			ConstLabels: constLabels,
 		}),
 
 		observationsReceived: prometheus.NewCounterVec(prometheus.CounterOpts{
-			Name: prometheus.BuildFQName("nats", "latency", "observations_received_count"),
-			Help: "Number of observations received by this surveyor across all services",
+			Name:        prometheus.BuildFQName("nats", "latency", "observations_received_count"),
+			Help:        "Number of observations received by this surveyor across all services",
+			ConstLabels: constLabels,
 		}, []string{"service", "app"}),
 
 		serviceRequestStatus: prometheus.NewCounterVec(prometheus.CounterOpts{
-			Name: prometheus.BuildFQName("nats", "latency", "observation_status_count"),
-			Help: "The status result codes for requests to a service",
+			Name:        prometheus.BuildFQName("nats", "latency", "observation_status_count"),
+			Help:        "The status result codes for requests to a service",
+			ConstLabels: constLabels,
 		}, []string{"service", "status"}),
 
 		invalidObservationsReceived: prometheus.NewCounterVec(prometheus.CounterOpts{
-			Name: prometheus.BuildFQName("nats", "latency", "observation_error_count"),
-			Help: "Number of observations received by this surveyor across all services that could not be handled",
+			Name:        prometheus.BuildFQName("nats", "latency", "observation_error_count"),
+			Help:        "Number of observations received by this surveyor across all services that could not be handled",
+			ConstLabels: constLabels,
 		}, []string{"service"}),
 
 		serviceLatency: prometheus.NewHistogramVec(prometheus.HistogramOpts{
-			Name: prometheus.BuildFQName("nats", "latency", "service_duration"),
-			Help: "Time spent serving the request in the service",
+			Name:        prometheus.BuildFQName("nats", "latency", "service_duration"),
+			Help:        "Time spent serving the request in the service",
+			ConstLabels: constLabels,
 		}, []string{"service", "app"}),
 
 		totalLatency: prometheus.NewHistogramVec(prometheus.HistogramOpts{
-			Name: prometheus.BuildFQName("nats", "latency", "total_duration"),
-			Help: "Total time spent serving a service including network overheads",
+			Name:        prometheus.BuildFQName("nats", "latency", "total_duration"),
+			Help:        "Total time spent serving a service including network overheads",
+			ConstLabels: constLabels,
 		}, []string{"service", "app"}),
 
 		requestorRTT: prometheus.NewHistogramVec(prometheus.HistogramOpts{
-			Name: prometheus.BuildFQName("nats", "latency", "requestor_rtt"),
-			Help: "The RTT to the client making a request",
+			Name:        prometheus.BuildFQName("nats", "latency", "requestor_rtt"),
+			Help:        "The RTT to the client making a request",
+			ConstLabels: constLabels,
 		}, []string{"service", "app"}),
 
 		responderRTT: prometheus.NewHistogramVec(prometheus.HistogramOpts{
-			Name: prometheus.BuildFQName("nats", "latency", "responder_rtt"),
-			Help: "The RTT to the service serving the request",
+			Name:        prometheus.BuildFQName("nats", "latency", "responder_rtt"),
+			Help:        "The RTT to the service serving the request",
+			ConstLabels: constLabels,
 		}, []string{"service", "app"}),
 
 		systemRTT: prometheus.NewHistogramVec(prometheus.HistogramOpts{
-			Name: prometheus.BuildFQName("nats", "latency", "system_rtt"),
-			Help: "The RTT within the NATS system - time traveling clusters, gateways and leaf nodes",
+			Name:        prometheus.BuildFQName("nats", "latency", "system_rtt"),
+			Help:        "The RTT within the NATS system - time traveling clusters, gateways and leaf nodes",
+			ConstLabels: constLabels,
 		}, []string{"service", "app"}),
 	}
 

--- a/surveyor/observation_test.go
+++ b/surveyor/observation_test.go
@@ -31,7 +31,7 @@ func TestServiceObservation_Load(t *testing.T) {
 	defer sc.Shutdown()
 
 	opt := getTestOptions()
-	metrics := NewServiceObservationMetrics(prometheus.NewRegistry())
+	metrics := NewServiceObservationMetrics(prometheus.NewRegistry(), nil)
 	reconnectCtr := prometheus.NewCounterVec(prometheus.CounterOpts{
 		Name: prometheus.BuildFQName("nats", "survey", "nats_reconnects"),
 		Help: "Number of times the surveyor reconnected to the NATS cluster",
@@ -64,7 +64,7 @@ func TestServiceObservation_Handle(t *testing.T) {
 	defer sc.Shutdown()
 
 	opt := getTestOptions()
-	metrics := NewServiceObservationMetrics(prometheus.NewRegistry())
+	metrics := NewServiceObservationMetrics(prometheus.NewRegistry(), nil)
 	reconnectCtr := prometheus.NewCounterVec(prometheus.CounterOpts{
 		Name: prometheus.BuildFQName("nats", "survey", "nats_reconnects"),
 		Help: "Number of times the surveyor reconnected to the NATS cluster",


### PR DESCRIPTION
This adds `ConstLabels`, a label map, to `surveyor.Options`. The option is not exposed via the CLI, but can be used programatically like so:

```go
s, err := surveyor.NewSurveyor(&Options{
	ConstLabels: prometheus.Labels{
		"foo": "bar",
		"baz": "qux",
	},
})
```

This adds constant labels to all exported metrics. For example:

```
nats_core_account_bytes_recv{account="AB7W",baz="qux",foo="bar"} 14004
```

If no `ConstLabels` are set, then the exported metrics will look exactly like before.

Fixes #95 