### PR TITLE
Prepare Release v0.4.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.18-alpine3.16 AS build
+FROM golang:1.19-alpine3.16 AS build
 COPY . /go/src/nats-surveyor
 WORKDIR /go/src/nats-surveyor
 ENV GO111MODULE=on

--- a/main.go
+++ b/main.go
@@ -1,4 +1,4 @@
-// Copyright 2017-2018 The NATS Authors
+// Copyright 2017-2022 The NATS Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at


### PR DESCRIPTION
Bumps Go version to Go 1.19 (latest)

Signed-off-by: Waldemar Quevedo <wally@nats.io>