### PR TITLE
[CHANGED] Log warnings instead of returning errors while processing.

### DIFF
--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -9,7 +9,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go: [ 1.18 ]
+        go: [ 1.19 ]
         os: [ ubuntu-latest, macOS-latest ]
     runs-on: ${{matrix.os}}
     steps:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/nats-io/nats-surveyor
 
-go 1.18
+go 1.19
 
 require (
 	github.com/antonfisher/nested-logrus-formatter v1.3.1

--- a/surveyor/observation.go
+++ b/surveyor/observation.go
@@ -326,25 +326,25 @@ func (s *Surveyor) watchObservations(dir string, depth int) error {
 	}
 
 	go func() {
-		s.Mutex.Lock()
+		s.Lock()
 		if _, ok := s.observationWatchers[dir]; ok {
 			return
 		}
 		watcher, err := fsnotify.NewWatcher()
 		if err != nil {
 			s.logger.Errorf("error creating watcher: %s", err)
-			s.Mutex.Unlock()
+			s.Unlock()
 			return
 		}
 
 		if err := watcher.Add(dir); err != nil {
 			s.logger.Errorf("error adding dir to watcher: %s", err)
-			s.Mutex.Unlock()
+			s.Unlock()
 			return
 		}
 		defer watcher.Close()
 		s.observationWatchers[dir] = struct{}{}
-		s.Mutex.Unlock()
+		s.Unlock()
 		s.logger.Debugf("starting listener goroutine for %s", dir)
 		for {
 			select {

--- a/surveyor/surveyor.go
+++ b/surveyor/surveyor.go
@@ -460,8 +460,6 @@ func (s *Surveyor) startObservations() {
 	if err := s.watchObservations(dir, 5); err != nil {
 		s.logger.Warnf("error starting observations watcher: %s", err)
 	}
-
-	return
 }
 
 func (s *Surveyor) Observations() []*ServiceObsListener {


### PR DESCRIPTION
This PR addresses surveyor stopping processing on invalid observation/unavailable account:
- if account/jetstream/connz info is not avaliable for an account, other accounts should be handler regardless
- invalid observation configuration is logged as warning instead of preventing surveyor startup