### PR TITLE
simplify ServiceObsManager

### DIFF
--- a/surveyor/observation.go
+++ b/surveyor/observation.go
@@ -314,7 +314,7 @@ type ServiceObsManager struct {
 	watcherStopChMap map[string]chan struct{}
 }
 
-// newServiceObservationManager creates an ObservationManager, allowing for adding/deleting service observations to the surveyor.
+// newServiceObservationManager creates a ServiceObsManager, allowing for adding/deleting service observations to the surveyor.
 func newServiceObservationManager(logger *logrus.Logger, sopts Options, metrics *ServiceObsMetrics, reconnectCtr *prometheus.CounterVec) *ServiceObsManager {
 	return &ServiceObsManager{
 		logger:           logger,

--- a/surveyor/observation.go
+++ b/surveyor/observation.go
@@ -20,14 +20,15 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strconv"
 	"strings"
+	"sync"
 
 	"github.com/fsnotify/fsnotify"
 	"github.com/nats-io/jsm.go"
 	"github.com/nats-io/jsm.go/api/server/metric"
 	"github.com/nats-io/nats.go"
-	"github.com/nats-io/nuid"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/sirupsen/logrus"
 )
@@ -115,37 +116,36 @@ func NewServiceObservationMetrics(registry *prometheus.Registry, constLabels pro
 }
 
 // ServiceObsListener listens for observations from nats service latency checks.
+//
+// Deprecated: ServiceObsListener will be unexported in a future release
+// Use ServiceObsConfig and Surveyor.ServiceObservationManager instead
 type ServiceObsListener struct {
-	nc          *nats.Conn
-	logger      *logrus.Logger
-	observation *ServiceObservation
-	metrics     *ServiceObsMetrics
-	sopts       *Options
+	nc      *nats.Conn
+	logger  *logrus.Logger
+	config  *ServiceObsConfig
+	metrics *ServiceObsMetrics
+	sopts   *Options
 }
 
-type ServiceObservation struct {
-	ID string
-	ObservationConfig
-}
-
-// ObservationConfig is used to set up new service observations.
-type ObservationConfig struct {
+// ServiceObsConfig is used to configure service observations
+type ServiceObsConfig struct {
+	ID          string `json:"id"`
 	ServiceName string `json:"name"`
 	Topic       string `json:"topic"`
 	Credentials string `json:"credential"`
 	Nkey        string `json:"nkey"`
 }
 
-// ObservationsManager exposes methods to operate on service observations.
-type ObservationsManager struct {
-	surveyor            *Surveyor
-	addObservations     chan addObservationsRequest
-	deleteObseravations chan deleteObservationsRequest
-	updateObservations  chan updateObservationsRequest
-}
+// Validate is used to validate a ServiceObsConfig
+func (o *ServiceObsConfig) Validate() error {
+	var errs []string
+	if o == nil {
+		return fmt.Errorf("service observation config cannot be nil")
+	}
 
-func (o *ObservationConfig) Validate() error {
-	errs := []string{}
+	if o.ID == "" {
+		errs = append(errs, "id is required")
+	}
 
 	if o.ServiceName == "" {
 		errs = append(errs, "name is required")
@@ -179,28 +179,39 @@ func (o *ObservationConfig) Validate() error {
 	return errors.New(strings.Join(errs, ", "))
 }
 
-// NewServiceObservationFromFile creates a new performance observation listener.
-func NewServiceObservationFromFile(f string, sopts Options, metrics *ServiceObsMetrics, reconnectCtr *prometheus.CounterVec) (*ServiceObsListener, error) {
+// NewServiceObservationConfigFromFile creates a new ServiceObsConfig from a file
+// the ID of the ServiceObsConfig is set to the filename f
+func NewServiceObservationConfigFromFile(f string) (*ServiceObsConfig, error) {
 	js, err := os.ReadFile(f)
 	if err != nil {
 		return nil, err
 	}
 
-	opts := &ObservationConfig{}
-	err = json.Unmarshal(js, opts)
+	obs := &ServiceObsConfig{}
+	err = json.Unmarshal(js, obs)
 	if err != nil {
-		return nil, fmt.Errorf("invalid service observation configuration: %s: %s", f, err)
+		return nil, fmt.Errorf("invalid service observation config: %s: %s", f, err)
 	}
-	err = opts.Validate()
+	obs.ID = f
+	err = obs.Validate()
 	if err != nil {
-		return nil, fmt.Errorf("invalid service observation configuration: %s: %s", f, err)
+		return nil, fmt.Errorf("invalid service observation config: %s: %s", f, err)
 	}
 
-	serviceObservation := &ServiceObservation{
-		ID:                f,
-		ObservationConfig: *opts,
+	return obs, nil
+}
+
+// NewServiceObservation creates a new service observation listener from a JSON file.
+//
+// Deprecated: ServiceObsListener will be unexported in a future release
+// Use NewServiceObservationConfigFromFile and Surveyor.ServiceObservationManager instead
+func NewServiceObservation(f string, sopts Options, metrics *ServiceObsMetrics, reconnectCtr *prometheus.CounterVec) (*ServiceObsListener, error) {
+	serviceObs, err := NewServiceObservationConfigFromFile(f)
+	if err != nil {
+		return nil, err
 	}
-	obs, err := newServiceObservation(*serviceObservation, sopts, metrics, reconnectCtr)
+
+	obs, err := newServiceObservationListener(serviceObs, sopts, metrics, reconnectCtr)
 	if err != nil {
 		return nil, err
 	}
@@ -208,30 +219,109 @@ func NewServiceObservationFromFile(f string, sopts Options, metrics *ServiceObsM
 	return obs, nil
 }
 
-func newServiceObservation(serviceObservation ServiceObservation, sopts Options, metrics *ServiceObsMetrics, reconnectCtr *prometheus.CounterVec) (*ServiceObsListener, error) {
-	err := serviceObservation.Validate()
+func newServiceObservationListener(serviceObs *ServiceObsConfig, sopts Options, metrics *ServiceObsMetrics, reconnectCtr *prometheus.CounterVec) (*ServiceObsListener, error) {
+	err := serviceObs.Validate()
 	if err != nil {
-		return nil, fmt.Errorf("invalid service observation configuration: %s: %s", serviceObservation.ServiceName, err)
+		return nil, fmt.Errorf("invalid service observation config: %s: %s", serviceObs.ServiceName, err)
 	}
 
-	sopts.Name = fmt.Sprintf("%s (observing %s)", sopts.Name, serviceObservation.ServiceName)
-	sopts.Credentials = serviceObservation.Credentials
-	sopts.Nkey = serviceObservation.Nkey
+	sopts.Name = fmt.Sprintf("%s (observing %s)", sopts.Name, serviceObs.ServiceName)
+	sopts.Credentials = serviceObs.Credentials
+	sopts.Nkey = serviceObs.Nkey
 	nc, err := connect(&sopts, reconnectCtr)
 	if err != nil {
 		return nil, fmt.Errorf("nats connection failed: %s", err)
 	}
 
 	return &ServiceObsListener{
-		nc:          nc,
-		logger:      sopts.Logger,
-		observation: &serviceObservation,
-		metrics:     metrics,
-		sopts:       &sopts,
+		nc:      nc,
+		logger:  sopts.Logger,
+		config:  serviceObs,
+		metrics: metrics,
+		sopts:   &sopts,
 	}, nil
 }
 
-func (s *Surveyor) startObservationsInDir() fs.WalkDirFunc {
+// Start starts listening for observations.
+func (o *ServiceObsListener) Start() error {
+	_, err := o.nc.Subscribe(o.config.Topic, o.observationHandler)
+	if err != nil {
+		return fmt.Errorf("could not subscribe to observation topic for %s (%s): %s", o.config.ServiceName, o.config.Topic, err)
+	}
+	err = o.nc.Flush()
+	if err != nil {
+		return err
+	}
+
+	o.metrics.observationsGauge.Inc()
+	o.logger.Infof("Started observing stats on %s for %s", o.config.Topic, o.config.ServiceName)
+
+	return nil
+}
+
+func (o *ServiceObsListener) observationHandler(m *nats.Msg) {
+	kind, obs, err := jsm.ParseEvent(m.Data)
+	if err != nil {
+		o.metrics.invalidObservationsReceived.WithLabelValues(o.config.ServiceName).Inc()
+		o.logger.Warnf("data: %s", m.Data)
+		o.logger.Warnf("Unparsable observation received on %s: %s", o.config.Topic, err)
+		return
+	}
+
+	switch obs := obs.(type) {
+	case *metric.ServiceLatencyV1:
+		o.metrics.observationsReceived.WithLabelValues(o.config.ServiceName, obs.Responder.Name).Inc()
+		o.metrics.serviceLatency.WithLabelValues(o.config.ServiceName, obs.Responder.Name).Observe(obs.ServiceLatency.Seconds())
+		o.metrics.totalLatency.WithLabelValues(o.config.ServiceName, obs.Responder.Name).Observe(obs.TotalLatency.Seconds())
+		o.metrics.requestorRTT.WithLabelValues(o.config.ServiceName, obs.Responder.Name).Observe(obs.Requestor.RTT.Seconds())
+		o.metrics.responderRTT.WithLabelValues(o.config.ServiceName, obs.Responder.Name).Observe(obs.Responder.RTT.Seconds())
+		o.metrics.systemRTT.WithLabelValues(o.config.ServiceName, obs.Responder.Name).Observe(obs.SystemLatency.Seconds())
+
+		if obs.Status == 0 {
+			o.metrics.serviceRequestStatus.WithLabelValues(o.config.ServiceName, "500").Inc()
+		} else {
+			o.metrics.serviceRequestStatus.WithLabelValues(o.config.ServiceName, strconv.Itoa(obs.Status)).Inc()
+		}
+
+	default:
+		o.metrics.invalidObservationsReceived.WithLabelValues(o.config.ServiceName).Inc()
+		o.logger.Warnf("Unsupported observation received on %s: %s", o.config.Topic, kind)
+		return
+	}
+}
+
+// Stop closes the connection to the network.
+func (o *ServiceObsListener) Stop() {
+	o.metrics.observationsGauge.Dec()
+	o.nc.Close()
+}
+
+// ServiceObsManager exposes methods to operate on service observations.
+type ServiceObsManager struct {
+	sync.Mutex
+	listenerMap      map[string]*ServiceObsListener
+	logger           *logrus.Logger
+	metrics          *ServiceObsMetrics
+	reconnectCtr     *prometheus.CounterVec
+	sopts            Options
+	running          bool
+	watcherStopChMap map[string]chan struct{}
+}
+
+// newServiceObservationManager creates an ObservationManager, allowing for adding/deleting service observations to the surveyor.
+func newServiceObservationManager(logger *logrus.Logger, sopts Options, metrics *ServiceObsMetrics, reconnectCtr *prometheus.CounterVec) *ServiceObsManager {
+	return &ServiceObsManager{
+		logger:           logger,
+		sopts:            sopts,
+		metrics:          metrics,
+		reconnectCtr:     reconnectCtr,
+		listenerMap:      map[string]*ServiceObsListener{},
+		watcherStopChMap: map[string]chan struct{}{},
+		running:          false,
+	}
+}
+
+func (om *ServiceObsManager) startObservationsInDir() fs.WalkDirFunc {
 	return func(path string, info fs.DirEntry, err error) error {
 		if err != nil {
 			return err
@@ -247,77 +337,16 @@ func (s *Surveyor) startObservationsInDir() fs.WalkDirFunc {
 			return nil
 		}
 
-		obs, err := NewServiceObservationFromFile(path, s.opts, s.observationMetrics, s.reconnectCtr)
+		obs, err := NewServiceObservationConfigFromFile(path)
 		if err != nil {
 			return fmt.Errorf("could not create observation from %s: %s", path, err)
 		}
 
-		err = obs.Start()
-		if err != nil {
-			return fmt.Errorf("could not start observation from %s: %s", path, err)
-		}
-
-		s.observations = append(s.observations, obs)
-
-		return nil
+		return om.Set(obs)
 	}
 }
 
-// Start starts listening for observations.
-func (o *ServiceObsListener) Start() error {
-	_, err := o.nc.Subscribe(o.observation.Topic, o.observationHandler)
-	if err != nil {
-		return fmt.Errorf("could not subscribe to observation topic for %s (%s): %s", o.observation.ServiceName, o.observation.Topic, err)
-	}
-	err = o.nc.Flush()
-	if err != nil {
-		return err
-	}
-
-	o.metrics.observationsGauge.Inc()
-	o.logger.Infof("Started observing stats on %s for %s", o.observation.Topic, o.observation.ServiceName)
-
-	return nil
-}
-
-func (o *ServiceObsListener) observationHandler(m *nats.Msg) {
-	kind, obs, err := jsm.ParseEvent(m.Data)
-	if err != nil {
-		o.metrics.invalidObservationsReceived.WithLabelValues(o.observation.ServiceName).Inc()
-		o.logger.Warnf("data: %s", m.Data)
-		o.logger.Warnf("Unparsable observation received on %s: %s", o.observation.Topic, err)
-		return
-	}
-
-	switch obs := obs.(type) {
-	case *metric.ServiceLatencyV1:
-		o.metrics.observationsReceived.WithLabelValues(o.observation.ServiceName, obs.Responder.Name).Inc()
-		o.metrics.serviceLatency.WithLabelValues(o.observation.ServiceName, obs.Responder.Name).Observe(obs.ServiceLatency.Seconds())
-		o.metrics.totalLatency.WithLabelValues(o.observation.ServiceName, obs.Responder.Name).Observe(obs.TotalLatency.Seconds())
-		o.metrics.requestorRTT.WithLabelValues(o.observation.ServiceName, obs.Responder.Name).Observe(obs.Requestor.RTT.Seconds())
-		o.metrics.responderRTT.WithLabelValues(o.observation.ServiceName, obs.Responder.Name).Observe(obs.Responder.RTT.Seconds())
-		o.metrics.systemRTT.WithLabelValues(o.observation.ServiceName, obs.Responder.Name).Observe(obs.SystemLatency.Seconds())
-
-		if obs.Status == 0 {
-			o.metrics.serviceRequestStatus.WithLabelValues(o.observation.ServiceName, "500").Inc()
-		} else {
-			o.metrics.serviceRequestStatus.WithLabelValues(o.observation.ServiceName, strconv.Itoa(obs.Status)).Inc()
-		}
-
-	default:
-		o.metrics.invalidObservationsReceived.WithLabelValues(o.observation.ServiceName).Inc()
-		o.logger.Warnf("Unsupported observation received on %s: %s", o.observation.Topic, kind)
-		return
-	}
-}
-
-// Stop closes the connection to the network.
-func (o *ServiceObsListener) Stop() {
-	o.metrics.observationsGauge.Dec()
-	o.nc.Close()
-}
-
-func (s *Surveyor) watchObservations(dir string, depth int) error {
+func (om *ServiceObsManager) watchObservations(dir string, depth int) error {
 	if depth == 0 {
 		return fmt.Errorf("exceeded observation dir max depth")
 	}
@@ -326,36 +355,51 @@ func (s *Surveyor) watchObservations(dir string, depth int) error {
 	}
 
 	go func() {
-		s.Lock()
-		if _, ok := s.observationWatchers[dir]; ok {
+		om.Lock()
+		if !om.running {
 			return
 		}
+
+		if _, ok := om.watcherStopChMap[dir]; ok {
+			om.Unlock()
+			return
+		}
+
 		watcher, err := fsnotify.NewWatcher()
 		if err != nil {
-			s.logger.Errorf("error creating watcher: %s", err)
-			s.Unlock()
+			om.Unlock()
+			om.logger.Errorf("error creating watcher: %s", err)
 			return
 		}
 
 		if err := watcher.Add(dir); err != nil {
-			s.logger.Errorf("error adding dir to watcher: %s", err)
-			s.Unlock()
+			om.Unlock()
+			om.logger.Errorf("error adding dir to watcher: %s", err)
 			return
 		}
-		defer watcher.Close()
-		s.observationWatchers[dir] = struct{}{}
-		s.Unlock()
-		s.logger.Debugf("starting listener goroutine for %s", dir)
+
+		stopCh := make(chan struct{}, 1)
+		om.watcherStopChMap[dir] = stopCh
+		om.Unlock()
+
+		defer func() {
+			om.Lock()
+			delete(om.watcherStopChMap, dir)
+			om.Unlock()
+			watcher.Close()
+		}()
+
+		om.logger.Debugf("starting listener goroutine for %s", dir)
 		for {
 			select {
 			case event, ok := <-watcher.Events:
 				if !ok {
 					return
 				}
-				if err := s.handleWatcherEvent(event, depth); err != nil {
-					s.logger.Warn(err)
+				if err := om.handleWatcherEvent(event, depth); err != nil {
+					om.logger.Warn(err)
 				}
-			case <-s.stop:
+			case <-stopCh:
 				return
 			}
 		}
@@ -363,23 +407,21 @@ func (s *Surveyor) watchObservations(dir string, depth int) error {
 	return nil
 }
 
-func (s *Surveyor) handleWatcherEvent(event fsnotify.Event, depth int) error {
+func (om *ServiceObsManager) handleWatcherEvent(event fsnotify.Event, depth int) error {
 	path := event.Name
-	s.Lock()
-	defer s.Unlock()
 
 	switch {
 	case event.Has(fsnotify.Create):
-		return s.handleCreateEvent(path, depth)
+		return om.handleCreateEvent(path, depth)
 	case event.Has(fsnotify.Write) && !event.Has(fsnotify.Remove):
-		return s.handleWriteEvent(path)
+		return om.handleWriteEvent(path)
 	case event.Has(fsnotify.Remove):
-		return s.handleRemoveEvent(path)
+		return om.handleRemoveEvent(path)
 	}
 	return nil
 }
 
-func (s *Surveyor) handleCreateEvent(path string, depth int) error {
+func (om *ServiceObsManager) handleCreateEvent(path string, depth int) error {
 	stat, err := os.Stat(path)
 	if err != nil {
 		return fmt.Errorf("could not read observation file %s: %s", path, err)
@@ -388,11 +430,11 @@ func (s *Surveyor) handleCreateEvent(path string, depth int) error {
 	// and then start watching for changes in this directory (fsnotify.Watcher is not recursive)
 	if stat.IsDir() && !strings.HasPrefix(stat.Name(), "..") {
 		depth--
-		err = filepath.WalkDir(path, s.startObservationsInDir())
+		err = filepath.WalkDir(path, om.startObservationsInDir())
 		if err != nil {
 			return fmt.Errorf("could not start observation from %s: %s", path, err)
 		}
-		if err := s.watchObservations(path, depth); err != nil {
+		if err := om.watchObservations(path, depth); err != nil {
 			return fmt.Errorf("could not start watcher in directory %s: %s", path, err)
 		}
 	}
@@ -401,323 +443,184 @@ func (s *Surveyor) handleCreateEvent(path string, depth int) error {
 		return nil
 	}
 
-	// create new observation from json
-	obs, err := NewServiceObservationFromFile(path, s.opts, s.observationMetrics, s.reconnectCtr)
-	if err != nil {
-		return fmt.Errorf("could not create observation from %s: %s", path, err)
-	}
-
-	// multiple create events for 1 file when using symlinks
-	// in such case, subsequent events should be ignored
-	// https://github.com/fsnotify/fsnotify/issues/277
-	for _, existingObservation := range s.observations {
-		if *existingObservation.observation == *obs.observation {
-			return nil
-		}
-	}
-	err = obs.Start()
-	if err != nil {
-		return fmt.Errorf("could not start observation from %s: %s", path, err)
-	}
-
-	s.observations = append(s.observations, obs)
-	return nil
+	// handle as a write event
+	return om.handleWriteEvent(path)
 }
 
-func (s *Surveyor) handleWriteEvent(path string) error {
-	fs, err := os.Stat(path)
+func (om *ServiceObsManager) handleWriteEvent(path string) error {
+	stat, err := os.Stat(path)
 	if err != nil {
 		return fmt.Errorf("could not read observation file %s: %s", path, err)
 	}
+
 	// if not a JSON, ignore
-	if filepath.Ext(fs.Name()) != ".json" {
+	if filepath.Ext(stat.Name()) != ".json" {
 		return nil
 	}
-	obs, err := NewServiceObservationFromFile(path, s.opts, s.observationMetrics, s.reconnectCtr)
+
+	obs, err := NewServiceObservationConfigFromFile(path)
 	if err != nil {
 		return fmt.Errorf("could not create observation from %s: %s", path, err)
 	}
 
-	err = obs.Start()
-	if err != nil {
-		return fmt.Errorf("could not start observation from %s: %s", path, err)
-	}
-
-	// if observation is updated, stop previous observation and overwrite with new one
-	for i, existingObservation := range s.observations {
-		if existingObservation.observation.ID == obs.observation.ID {
-			existingObservation.Stop()
-			s.observations[i] = obs
-			return nil
-		}
-	}
-	s.observations = append(s.observations, obs)
-	return nil
+	return om.Set(obs)
 }
 
-func (s *Surveyor) handleRemoveEvent(path string) error {
-	// directory removed, delete all observations inside and cancel watching this dir
-	if _, ok := s.observationWatchers[path]; ok {
-		for i := 0; ; i++ {
-			if i > len(s.observations)-1 {
-				break
-			}
-			if strings.HasPrefix(s.observations[i].observation.ID, path) {
-				s.observations = removeObservation(s.observations, i)
-				i--
+func (om *ServiceObsManager) handleRemoveEvent(path string) error {
+	var removeIDs []string
+
+	om.Lock()
+	if stopCh, ok := om.watcherStopChMap[path]; ok {
+		// directory removed, delete all observations inside and cancel watching this dir
+		prefix := strings.TrimSuffix(path, string(filepath.Separator)) + string(filepath.Separator)
+		for id := range om.listenerMap {
+			if strings.HasPrefix(id, prefix) {
+				removeIDs = append(removeIDs, id)
 			}
 		}
-		delete(s.observationWatchers, path)
+		stopCh <- struct{}{}
+	} else if _, ok := om.listenerMap[path]; ok {
+		// JSON file exists
+		removeIDs = append(removeIDs, path)
+	}
+	om.Unlock()
+
+	var err error
+	if len(removeIDs) > 0 {
+		for _, removeID := range removeIDs {
+			if removeErr := om.Delete(removeID); removeErr != nil {
+				err = removeErr
+			}
+		}
+	}
+
+	return err
+}
+
+func (om *ServiceObsManager) start() {
+	om.Lock()
+	defer om.Unlock()
+	if om.running {
+		return
+	}
+
+	om.running = true
+}
+
+// IsRunning returns true if the observation manager is running or false if it is stopped
+func (om *ServiceObsManager) IsRunning() bool {
+	om.Lock()
+	defer om.Unlock()
+	return om.running
+}
+
+func (om *ServiceObsManager) stop() {
+	om.Lock()
+	defer om.Unlock()
+	if !om.running {
+		return
+	}
+
+	for _, obs := range om.listenerMap {
+		obs.Stop()
+	}
+	om.listenerMap = map[string]*ServiceObsListener{}
+
+	for _, watcherStopCh := range om.watcherStopChMap {
+		watcherStopCh <- struct{}{}
+	}
+	om.watcherStopChMap = map[string]chan struct{}{}
+
+	om.metrics.observationsGauge.Set(0)
+	om.running = false
+}
+
+// ConfigMap returns a map of id:*ServiceObsConfig for all running observations.
+func (om *ServiceObsManager) ConfigMap() map[string]*ServiceObsConfig {
+	om.Lock()
+	defer om.Unlock()
+
+	obsMap := make(map[string]*ServiceObsConfig, len(om.listenerMap))
+	for id, obs := range om.listenerMap {
+		// copy value so that it can't be changed
+		obsMap[id] = &ServiceObsConfig{}
+		*obsMap[id] = *obs.config
+	}
+
+	return obsMap
+}
+
+// Set creates or updates an observation
+// if an observation exists with the same ID, it is updated
+// otherwise, a new observation is created
+func (om *ServiceObsManager) Set(config *ServiceObsConfig) error {
+	err := config.Validate()
+	if err != nil {
+		return err
+	}
+
+	{
+		// copy value so that it can't be changed
+		configCp := &ServiceObsConfig{}
+		*configCp = *config
+		config = configCp
+	}
+
+	om.Lock()
+	if !om.running {
+		om.Unlock()
+		return fmt.Errorf("could not set observation for service: %s: observation manager is stopped", config.ServiceName)
+	}
+
+	existingObs, found := om.listenerMap[config.ID]
+	om.Unlock()
+
+	if found && reflect.DeepEqual(config, existingObs.config) {
 		return nil
 	}
-	// if not a directory and not a JSON, ignore
-	if filepath.Ext(path) != ".json" {
-		return nil
-	}
-	for i := 0; ; i++ {
-		if i > len(s.observations)-1 {
-			break
-		}
-		if s.observations[i].observation.ID == path {
-			s.observations = removeObservation(s.observations, i)
-			i--
-		}
-	}
-	return nil
-}
 
-func removeObservation(observations []*ServiceObsListener, i int) []*ServiceObsListener {
-	if i >= len(observations) {
-		return observations
-	}
-	observations[i].Stop()
-	if i < len(observations)-1 {
-		observations = append(observations[:i], observations[i+1:]...)
-	} else {
-		observations = observations[:i]
-	}
-	return observations
-}
-
-// ServiceObservationResult contains the result of adding/removing service observations.
-type ServiceObservationResult struct {
-	ServiceObservation *ServiceObservation
-	Err                error
-}
-
-// DeleteObservationResult contains the result of adding/removing service observations.
-type DeleteObservationResult struct {
-	ObservationID string
-	Err           error
-}
-
-type addObservationsRequest struct {
-	configs []ObservationConfig
-	resp    chan ServiceObservationResult
-}
-
-type updateObservationsRequest struct {
-	obs  []ServiceObservation
-	resp chan ServiceObservationResult
-}
-
-type deleteObservationsRequest struct {
-	obsIDs []string
-	resp   chan DeleteObservationResult
-}
-
-// ManageObservations creates an ObservationManager, allowing for adding/deleting service observations to the surveyor.
-func (s *Surveyor) ManageObservations() (*ObservationsManager, error) {
-	obsManager := &ObservationsManager{
-		surveyor:            s,
-		addObservations:     make(chan addObservationsRequest, 100),
-		updateObservations:  make(chan updateObservationsRequest, 100),
-		deleteObseravations: make(chan deleteObservationsRequest, 100),
-	}
-	go func() {
-		for {
-			select {
-			case req := <-obsManager.addObservations:
-				for _, config := range req.configs {
-					res, err := obsManager.addObservation(config)
-					if err != nil {
-						s.logger.Warnf("adding service observation: %s", err)
-					}
-					req.resp <- ServiceObservationResult{
-						ServiceObservation: res,
-						Err:                err,
-					}
-				}
-				close(req.resp)
-			case req := <-obsManager.updateObservations:
-				for _, observation := range req.obs {
-					res, err := obsManager.updateObservation(observation)
-					if err != nil {
-						s.logger.Warnf("updating service observation: %s", err)
-					}
-					req.resp <- ServiceObservationResult{
-						ServiceObservation: res,
-						Err:                err,
-					}
-				}
-				close(req.resp)
-			case req := <-obsManager.deleteObseravations:
-				for _, id := range req.obsIDs {
-					err := obsManager.deleteObservation(id)
-					if err != nil {
-						s.logger.Warnf("deleting service observation: %s", err)
-					}
-					req.resp <- DeleteObservationResult{
-						ObservationID: id,
-						Err:           err,
-					}
-				}
-				close(req.resp)
-			case <-s.stop:
-				return
-			}
-		}
-	}()
-	return obsManager, nil
-}
-
-// AddObservations creates and starts new service observations.
-// The returned channel is always closed and is safe to iterate over with "range".
-//
-//	results := obsManager.AddObservations(observations...)
-//	for resp := range results {
-//		if resp.Err != nil {
-//			return err
-//		}
-//		fmt.Println("Created observation with ID: ", resp.ServiceObservation.ObservationID)
-//	}
-func (om *ObservationsManager) AddObservations(observations ...ObservationConfig) <-chan ServiceObservationResult {
-	resp := make(chan ServiceObservationResult, len(observations))
-
-	req := addObservationsRequest{
-		configs: observations,
-		resp:    resp,
-	}
-	om.addObservations <- req
-	return resp
-}
-
-// DeleteObservations deletes exisiting observations with provided service names.
-// The returned channel is always closed and is safe to iterate over with "range".
-//
-//	results := obsManager.DeleteObservations(ids...)
-//	for resp := range results {
-//		if resp.Err != nil {
-//			return err
-//		}
-//		fmt.Println("Deleted observation with ID: ", resp.ObservationID)
-//	}
-func (om *ObservationsManager) DeleteObservations(ids ...string) <-chan DeleteObservationResult {
-	resp := make(chan DeleteObservationResult, len(ids))
-	om.deleteObseravations <- deleteObservationsRequest{
-		obsIDs: ids,
-		resp:   resp,
-	}
-	return resp
-}
-
-// UpdateObservations updates exisiting observations.
-// Service observation with provided ID has to exist for the update to succeed.
-// The returned channel is always closed and is safe to iterate over with "range".
-//
-//	results := obsManager.UpdateObservations(observations...)
-//	for resp := range results {
-//		if resp.Err != nil {
-//			return err
-//		}
-//		fmt.Println("Updated observation with ID: ", resp.ObservationID)
-//	}
-func (om *ObservationsManager) UpdateObservations(observations ...ServiceObservation) <-chan ServiceObservationResult {
-	resp := make(chan ServiceObservationResult)
-	req := updateObservationsRequest{
-		obs:  observations,
-		resp: resp,
-	}
-	om.updateObservations <- req
-	return resp
-}
-
-// GetObservations returns configs of all running service observations.
-func (om *ObservationsManager) GetObservations() []ServiceObservation {
-	om.surveyor.Lock()
-	defer om.surveyor.Unlock()
-	observations := make([]ServiceObservation, 0, len(om.surveyor.observations))
-	for _, obs := range om.surveyor.observations {
-		observations = append(observations, *obs.observation)
-	}
-	return observations
-}
-
-func (om *ObservationsManager) addObservation(req ObservationConfig) (*ServiceObservation, error) {
-	om.surveyor.Lock()
-	defer om.surveyor.Unlock()
-	serviceObservation := ServiceObservation{
-		ID:                nuid.Next(),
-		ObservationConfig: req,
-	}
-	obs, err := newServiceObservation(serviceObservation, om.surveyor.opts, om.surveyor.observationMetrics, om.surveyor.reconnectCtr)
+	obs, err := newServiceObservationListener(config, om.sopts, om.metrics, om.reconnectCtr)
 	if err != nil {
-		return nil, fmt.Errorf("could not create observation from config: %s: %s", req.ServiceName, err)
+		return fmt.Errorf("could not update observation for service: %s: %s", config.ServiceName, err)
 	}
 
 	if err := obs.Start(); err != nil {
-		return nil, fmt.Errorf("could not start observation for service: %s: %s", req.ServiceName, err)
+		return fmt.Errorf("could not start updated observation for service: %s: %s", config.ServiceName, err)
 	}
 
-	om.surveyor.observations = append(om.surveyor.observations, obs)
-	return obs.observation, nil
+	om.Lock()
+	if !om.running {
+		om.Unlock()
+		obs.Stop()
+		return fmt.Errorf("could not set observation for service: %s: observation manager is stopped", config.ServiceName)
+	}
+
+	om.listenerMap[config.ID] = obs
+	om.Unlock()
+
+	if found {
+		existingObs.Stop()
+	}
+	return nil
 }
 
-func (om *ObservationsManager) updateObservation(req ServiceObservation) (*ServiceObservation, error) {
-	om.surveyor.Lock()
-	defer om.surveyor.Unlock()
-	var found bool
-	var obsIndex int
-	for i, existingObservation := range om.surveyor.observations {
-		if req.ID == existingObservation.observation.ID {
-			found = true
-			obsIndex = i
-			break
-		}
-	}
-	if !found {
-		return nil, fmt.Errorf("observation with provided ID does not exist: %s", req.ID)
-	}
-	obs, err := newServiceObservation(req, om.surveyor.opts, om.surveyor.observationMetrics, om.surveyor.reconnectCtr)
-	if err != nil {
-		return nil, fmt.Errorf("could not create observation from config: %s: %s", req.ServiceName, err)
-	}
-	if err := obs.Start(); err != nil {
-		return nil, fmt.Errorf("could not start observation for service: %s: %s", req.ServiceName, err)
+// Delete deletes existing observations with provided ID
+func (om *ServiceObsManager) Delete(id string) error {
+	om.Lock()
+	if !om.running {
+		om.Unlock()
+		return fmt.Errorf("could not delete observation id: %s: observation manager is stopped", id)
 	}
 
-	om.surveyor.observations[obsIndex].Stop()
-	om.surveyor.observations[obsIndex] = obs
-	return obs.observation, nil
-}
-
-func (om *ObservationsManager) deleteObservation(id string) error {
-	om.surveyor.Lock()
-	defer om.surveyor.Unlock()
-	var found bool
-	for i, existingObservation := range om.surveyor.observations {
-		if id == existingObservation.observation.ID {
-			found = true
-			existingObservation.Stop()
-			if i < len(om.surveyor.observations)-1 {
-				om.surveyor.observations = append(om.surveyor.observations[:i], om.surveyor.observations[i+1:]...)
-			} else {
-				om.surveyor.observations = om.surveyor.observations[:i]
-			}
-		}
-	}
+	existingObs, found := om.listenerMap[id]
 	if !found {
+		om.Unlock()
 		return fmt.Errorf("observation with given ID does not exist: %s", id)
 	}
+
+	delete(om.listenerMap, id)
+	om.Unlock()
+
+	existingObs.Stop()
 	return nil
 }

--- a/surveyor/observation_test.go
+++ b/surveyor/observation_test.go
@@ -37,23 +37,23 @@ func TestServiceObservation_Load(t *testing.T) {
 		Help: "Number of times the surveyor reconnected to the NATS cluster",
 	}, []string{"name"})
 
-	obs, err := NewServiceObservationFromFile("testdata/goodobs/good.json", *opt, metrics, reconnectCtr)
+	obs, err := NewServiceObservation("testdata/goodobs/good.json", *opt, metrics, reconnectCtr)
 	if err != nil {
 		t.Fatalf("observation load error: %s", err)
 	}
 	obs.Stop()
 
-	_, err = NewServiceObservationFromFile("testdata/badobs/missing.json", *opt, metrics, reconnectCtr)
+	_, err = NewServiceObservation("testdata/badobs/missing.json", *opt, metrics, reconnectCtr)
 	if err.Error() != "open testdata/badobs/missing.json: no such file or directory" {
 		t.Fatalf("observation load error: %s", err)
 	}
 
-	_, err = NewServiceObservationFromFile("testdata/badobs/bad.json", *opt, metrics, reconnectCtr)
-	if err.Error() != "invalid service observation configuration: testdata/badobs/bad.json: name is required, topic is required, jwt or nkey credentials is required" {
+	_, err = NewServiceObservation("testdata/badobs/bad.json", *opt, metrics, reconnectCtr)
+	if err.Error() != "invalid service observation config: testdata/badobs/bad.json: name is required, topic is required, jwt or nkey credentials is required" {
 		t.Fatalf("observation load error: %s", err)
 	}
 
-	_, err = NewServiceObservationFromFile("testdata/badobs/badauth.json", *opt, metrics, reconnectCtr)
+	_, err = NewServiceObservation("testdata/badobs/badauth.json", *opt, metrics, reconnectCtr)
 	if err.Error() != "nats connection failed: nats: Authorization Violation" {
 		t.Fatalf("observation load error: %s", err)
 	}
@@ -70,23 +70,23 @@ func TestServiceObservation_LoadDynamically(t *testing.T) {
 		Help: "Number of times the surveyor reconnected to the NATS cluster",
 	}, []string{"name"})
 
-	obs, err := NewServiceObservationFromFile("testdata/goodobs/good.json", *opt, metrics, reconnectCtr)
+	obs, err := NewServiceObservation("testdata/goodobs/good.json", *opt, metrics, reconnectCtr)
 	if err != nil {
 		t.Fatalf("observation load error: %s", err)
 	}
 	obs.Stop()
 
-	_, err = NewServiceObservationFromFile("testdata/badobs/missing.json", *opt, metrics, reconnectCtr)
+	_, err = NewServiceObservation("testdata/badobs/missing.json", *opt, metrics, reconnectCtr)
 	if err.Error() != "open testdata/badobs/missing.json: no such file or directory" {
 		t.Fatalf("observation load error: %s", err)
 	}
 
-	_, err = NewServiceObservationFromFile("testdata/badobs/bad.json", *opt, metrics, reconnectCtr)
-	if err.Error() != "invalid service observation configuration: testdata/badobs/bad.json: name is required, topic is required, jwt or nkey credentials is required" {
+	_, err = NewServiceObservation("testdata/badobs/bad.json", *opt, metrics, reconnectCtr)
+	if err.Error() != "invalid service observation config: testdata/badobs/bad.json: name is required, topic is required, jwt or nkey credentials is required" {
 		t.Fatalf("observation load error: %s", err)
 	}
 
-	_, err = NewServiceObservationFromFile("testdata/badobs/badauth.json", *opt, metrics, reconnectCtr)
+	_, err = NewServiceObservation("testdata/badobs/badauth.json", *opt, metrics, reconnectCtr)
 	if err.Error() != "nats connection failed: nats: Authorization Violation" {
 		t.Fatalf("observation load error: %s", err)
 	}
@@ -103,7 +103,7 @@ func TestServiceObservation_Handle(t *testing.T) {
 		Help: "Number of times the surveyor reconnected to the NATS cluster",
 	}, []string{"name"})
 
-	obs, err := NewServiceObservationFromFile("testdata/goodobs/good.json", *opt, metrics, reconnectCtr)
+	obs, err := NewServiceObservation("testdata/goodobs/good.json", *opt, metrics, reconnectCtr)
 	if err != nil {
 		t.Fatalf("observation load error: %s", err)
 	}

--- a/surveyor/surveyor.go
+++ b/surveyor/surveyor.go
@@ -110,7 +110,7 @@ type Surveyor struct {
 	reconnectCtr        *prometheus.CounterVec
 	statzC              *StatzCollector
 	serviceObsManager   *ServiceObsManager
-	serviceObsFsWatcher *serviceObsFsWatcher
+	serviceObsFsWatcher *serviceObsFSWatcher
 	jsAPIMetrics        *JSAdvisoryMetrics
 	jsAPIAudits         []*JSAdvisoryListener
 	stop                chan struct{}
@@ -187,7 +187,7 @@ func NewSurveyor(opts *Options) (*Surveyor, error) {
 	promRegistry.MustRegister(reconnectCtr)
 	serviceObsMetrics := NewServiceObservationMetrics(promRegistry, opts.ConstLabels)
 	serviceObsManager := newServiceObservationManager(opts.Logger, *opts, serviceObsMetrics, reconnectCtr)
-	serviceObsFsWatcher := newServiceObsFsWatcher(opts.Logger, serviceObsManager)
+	serviceObsFsWatcher := newServiceObservationFSWatcher(opts.Logger, serviceObsManager)
 	jsAPIMetrics := NewJetStreamAdvisoryMetrics(promRegistry, opts.ConstLabels)
 
 	return &Surveyor{

--- a/surveyor/surveyor_test.go
+++ b/surveyor/surveyor_test.go
@@ -21,6 +21,7 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -431,7 +432,7 @@ func TestSurveyor_ObservationsFromFile(t *testing.T) {
 	}
 	defer s.Stop()
 
-	if ptu.ToFloat64(s.observationMetrics.observationsGauge) != 1 {
+	if ptu.ToFloat64(s.ServiceObservationManager().metrics.observationsGauge) != 1 {
 		t.Fatalf("process error: observations not started")
 	}
 }
@@ -446,64 +447,61 @@ func TestSurveyor_Observations(t *testing.T) {
 	if err != nil {
 		t.Fatalf("couldn't create surveyor: %v", err)
 	}
-
-	expectedObservations := make(map[string]ObservationConfig)
 	if err = s.Start(); err != nil {
 		t.Fatalf("start error: %v", err)
 	}
 	defer s.Stop()
-	obsManager, err := s.ManageObservations()
-	if err != nil {
-		t.Fatalf("Error creating observations manager: %s", err)
-	}
+	om := s.ServiceObservationManager()
 
-	observations := []ObservationConfig{
+	expectedObservations := make(map[string]*ServiceObsConfig)
+	observations := []*ServiceObsConfig{
 		{
+			ID:          "srv1",
 			ServiceName: "srv1",
 			Topic:       "testing.topic",
 			Credentials: "../test/myuser.creds",
+			Nkey:        "",
 		},
 		{
+			ID:          "srv2",
 			ServiceName: "srv2",
 			Topic:       "testing.topic",
 			Credentials: "../test/myuser.creds",
 		},
 		{
+			ID:          "srv3",
 			ServiceName: "srv3",
 			Topic:       "testing.topic",
 			Credentials: "../test/myuser.creds",
 		},
 	}
-	results := obsManager.AddObservations(observations...)
 
 	obsIDs := make([]string, 0)
-	for resp := range results {
-		if resp.Err != nil {
-			t.Errorf("Unexpected error on observation add request: %s", resp.Err)
+	for _, obs := range observations {
+		err := om.Set(obs)
+		if err != nil {
+			t.Errorf("Unexpected error on observation set: %s", err)
 		}
-		obsIDs = append(obsIDs, resp.ServiceObservation.ID)
-		expectedObservations[resp.ServiceObservation.ID] = resp.ServiceObservation.ObservationConfig
+		obsIDs = append(obsIDs, obs.ID)
+		expectedObservations[obs.ID] = obs
 	}
-	waitForMetricUpdate(t, obsManager, expectedObservations)
+	waitForMetricUpdate(t, om, expectedObservations)
 
-	updateObservationReq := ServiceObservation{
-		ID: obsIDs[0],
-		ObservationConfig: ObservationConfig{
-			ServiceName: "srv4",
-			Topic:       "testing_updated.topic",
-			Credentials: "../test/myuser.creds",
-		},
+	setObservation := &ServiceObsConfig{
+		ID:          obsIDs[0],
+		ServiceName: "srv4",
+		Topic:       "testing_updated.topic",
+		Credentials: "../test/myuser.creds",
 	}
-	expectedObservations[obsIDs[0]] = updateObservationReq.ObservationConfig
-	results = obsManager.UpdateObservations(updateObservationReq)
-	for resp := range results {
-		if resp.Err != nil {
-			t.Fatalf("Unexpected error during observation update: %s", resp.Err)
-		}
+	expectedObservations[obsIDs[0]] = setObservation
+	err = om.Set(setObservation)
+	if err != nil {
+		t.Errorf("Unexpected error on observation set: %s", err)
 	}
-	waitForMetricUpdate(t, obsManager, expectedObservations)
+	waitForMetricUpdate(t, om, expectedObservations)
 	var found bool
-	for _, obs := range obsManager.GetObservations() {
+	obsMap := om.ConfigMap()
+	for _, obs := range obsMap {
 		if obs.ServiceName == "srv4" {
 			found = true
 			break
@@ -514,21 +512,19 @@ func TestSurveyor_Observations(t *testing.T) {
 		t.Errorf("Expected updated service name in observations: %s", "srv4")
 	}
 	deleteID := obsIDs[0]
-	deleteResult := obsManager.DeleteObservations(deleteID)
+	err = om.Delete(deleteID)
 	delete(expectedObservations, deleteID)
-	resp := <-deleteResult
-	if resp.Err != nil {
-		t.Errorf("Unexpected error on observation delete request: %s", resp.Err)
+	if err != nil {
+		t.Errorf("Unexpected error on observation delete request: %s", err)
 	}
-	waitForMetricUpdate(t, obsManager, expectedObservations)
+	waitForMetricUpdate(t, om, expectedObservations)
 
 	// observation no longer exists
-	deleteResult = obsManager.DeleteObservations(deleteID)
-	resp = <-deleteResult
-	if resp.Err == nil {
+	err = om.Delete(deleteID)
+	if err == nil {
 		t.Error("Expected error; got nil")
 	}
-	waitForMetricUpdate(t, obsManager, expectedObservations)
+	waitForMetricUpdate(t, om, expectedObservations)
 }
 
 func TestSurveyor_ObservationsError(t *testing.T) {
@@ -545,73 +541,55 @@ func TestSurveyor_ObservationsError(t *testing.T) {
 		t.Fatalf("start error: %v", err)
 	}
 	defer s.Stop()
-	obsManager, err := s.ManageObservations()
+	om := s.ServiceObservationManager()
 	if err != nil {
 		t.Fatalf("Error creating observations manager: %s", err)
 	}
 
 	// add invalid observation (missing service name)
-	result := obsManager.AddObservations(
-		ObservationConfig{
+	err = om.Set(
+		&ServiceObsConfig{
+			ID:          "id",
 			ServiceName: "",
 			Topic:       "testing.topic",
 			Credentials: "../test/myuser.creds",
 		},
 	)
 
-	var addErr error
-	for resp := range result {
-		if resp.Err != nil {
-			addErr = resp.Err
-		}
-	}
-	if addErr == nil {
+	if err == nil {
 		t.Errorf("Expected error; got nil")
 	}
 
 	// valid observation, no error
-	result = obsManager.AddObservations(
-		ObservationConfig{
+	err = om.Set(
+		&ServiceObsConfig{
+			ID:          "id",
 			ServiceName: "srv",
 			Topic:       "testing.topic",
 			Credentials: "../test/myuser.creds",
 		},
 	)
 
-	addErr = nil
-	for resp := range result {
-		if resp.Err != nil {
-			addErr = resp.Err
-		}
-	}
-	if addErr != nil {
-		t.Errorf("Expected no error; got: %s", addErr)
+	if err != nil {
+		t.Errorf("Expected no error; got: %s", err)
 	}
 
 	// update error, invalid config
-	result = obsManager.UpdateObservations(
-		ServiceObservation{
-			ID: "srv",
-			ObservationConfig: ObservationConfig{
-				ServiceName: "srv",
-				Topic:       "",
-				Credentials: "../test/myuser.creds",
-			},
+	err = om.Set(
+		&ServiceObsConfig{
+			ID:          "srv",
+			ServiceName: "srv",
+			Topic:       "",
+			Credentials: "../test/myuser.creds",
 		},
 	)
 
-	var updateErr error
-	for resp := range result {
-		if resp.Err != nil {
-			updateErr = resp.Err
-		}
-	}
-	if updateErr == nil {
+	if err == nil {
 		t.Errorf("Expected error; got nil")
 	}
 }
 
-func waitForMetricUpdate(t *testing.T, om *ObservationsManager, expectedObservations map[string]ObservationConfig) {
+func waitForMetricUpdate(t *testing.T, om *ServiceObsManager, expectedObservations map[string]*ServiceObsConfig) {
 	t.Helper()
 	ticker := time.NewTicker(50 * time.Millisecond)
 	timeout := time.After(5 * time.Second)
@@ -620,18 +598,18 @@ Outer:
 	for {
 		select {
 		case <-ticker.C:
-			observationsNum := ptu.ToFloat64(om.surveyor.observationMetrics.observationsGauge)
+			observationsNum := ptu.ToFloat64(om.metrics.observationsGauge)
 			if observationsNum == float64(len(expectedObservations)) {
 				break Outer
 			}
 		case <-timeout:
-			observationsNum := ptu.ToFloat64(om.surveyor.observationMetrics.observationsGauge)
+			observationsNum := ptu.ToFloat64(om.metrics.observationsGauge)
 			t.Fatalf("process error: invalid number of observations; want: %d; got: %f\n", len(expectedObservations), observationsNum)
 			return
 		}
 	}
 
-	existingObservations := om.GetObservations()
+	existingObservations := om.ConfigMap()
 	if len(existingObservations) != len(expectedObservations) {
 		t.Fatalf("Unexpected number of observations; want: %d; got: %d", len(expectedObservations), len(existingObservations))
 	}
@@ -640,8 +618,8 @@ Outer:
 		if !ok {
 			t.Fatalf("Missing observation with ID: %s", existingObservation.ID)
 		}
-		if obs != existingObservation.ObservationConfig {
-			t.Fatalf("Invalid observation config; want: %+v; got: %+v", obs, existingObservation.ObservationConfig)
+		if !reflect.DeepEqual(obs, existingObservation) {
+			t.Fatalf("Invalid observation config; want: %+v; got: %+v", obs, existingObservation)
 		}
 	}
 }
@@ -666,18 +644,14 @@ func TestSurveyor_ObservationsWatcher(t *testing.T) {
 	if err = s.Start(); err != nil {
 		t.Fatalf("start error: %v", err)
 	}
+	defer s.Stop()
 	time.Sleep(200 * time.Millisecond)
 
-	defer s.Stop()
-
-	om, err := s.ManageObservations()
-	if err != nil {
-		t.Fatalf("Unexpected error: %s", err)
-	}
-	expectedObservations := make(map[string]ObservationConfig)
+	om := s.ServiceObservationManager()
+	expectedObservations := make(map[string]*ServiceObsConfig)
 
 	t.Run("write observation file - create operation", func(t *testing.T) {
-		obsConfig := ObservationConfig{
+		obsConfig := &ServiceObsConfig{
 			ServiceName: "testing1",
 			Topic:       "testing1.topic",
 			Credentials: "../test/myuser.creds",
@@ -691,12 +665,13 @@ func TestSurveyor_ObservationsWatcher(t *testing.T) {
 			t.Fatalf("Error writing observation config file: %s", err)
 		}
 
+		obsConfig.ID = obsPath
 		expectedObservations[obsPath] = obsConfig
 		waitForMetricUpdate(t, om, expectedObservations)
 	})
 
 	t.Run("first create then write to file - write operation", func(t *testing.T) {
-		obsConfig := ObservationConfig{
+		obsConfig := &ServiceObsConfig{
 			ServiceName: "testing2",
 			Topic:       "testing2.topic",
 			Credentials: "../test/myuser.creds",
@@ -718,12 +693,13 @@ func TestSurveyor_ObservationsWatcher(t *testing.T) {
 			t.Fatalf("Error writing to file: %s", err)
 		}
 
+		obsConfig.ID = obsPath
 		expectedObservations[obsPath] = obsConfig
 		waitForMetricUpdate(t, om, expectedObservations)
 	})
 
 	t.Run("create observations in subfolder", func(t *testing.T) {
-		obsConfig := ObservationConfig{
+		obsConfig := &ServiceObsConfig{
 			ServiceName: "testing3",
 			Topic:       "testing3.topic",
 			Credentials: "../test/myuser.creds",
@@ -745,10 +721,11 @@ func TestSurveyor_ObservationsWatcher(t *testing.T) {
 			t.Fatalf("Error writing observation config file: %s", err)
 		}
 
+		obsConfig.ID = obsPath
 		expectedObservations[obsPath] = obsConfig
 		waitForMetricUpdate(t, om, expectedObservations)
 
-		obsConfig = ObservationConfig{
+		obsConfig = &ServiceObsConfig{
 			ServiceName: "testing4",
 			Topic:       "testing4.topic",
 			Credentials: "../test/myuser.creds",
@@ -763,10 +740,11 @@ func TestSurveyor_ObservationsWatcher(t *testing.T) {
 			t.Fatalf("Error writing observation config file: %s", err)
 		}
 
+		obsConfig.ID = obsPath
 		expectedObservations[obsPath] = obsConfig
 		waitForMetricUpdate(t, om, expectedObservations)
 
-		obsConfig = ObservationConfig{
+		obsConfig = &ServiceObsConfig{
 			ServiceName: "testing5",
 			Topic:       "testing5.topic",
 			Credentials: "../test/myuser.creds",
@@ -786,12 +764,13 @@ func TestSurveyor_ObservationsWatcher(t *testing.T) {
 			t.Fatalf("Error writing observation config file: %s", err)
 		}
 
+		obsConfig.ID = obsPath
 		expectedObservations[obsPath] = obsConfig
 		waitForMetricUpdate(t, om, expectedObservations)
 	})
 
 	t.Run("update observations", func(t *testing.T) {
-		obsConfig := ObservationConfig{
+		obsConfig := &ServiceObsConfig{
 			ServiceName: "testing_updated",
 			Topic:       "testing_updated.topic",
 			Credentials: "../test/myuser.creds",
@@ -806,6 +785,7 @@ func TestSurveyor_ObservationsWatcher(t *testing.T) {
 			t.Fatalf("Error writing to file: %s", err)
 		}
 
+		obsConfig.ID = obsPath
 		expectedObservations[obsPath] = obsConfig
 		waitForMetricUpdate(t, om, expectedObservations)
 
@@ -836,7 +816,7 @@ func TestSurveyor_ObservationsWatcher(t *testing.T) {
 		delete(expectedObservations, fmt.Sprintf("%s/subdir/nested/nested.json", dirName))
 		waitForMetricUpdate(t, om, expectedObservations)
 
-		obsConfig := ObservationConfig{
+		obsConfig := &ServiceObsConfig{
 			ServiceName: "testing10",
 			Topic:       "testing1.topic",
 			Credentials: "../test/myuser.creds",
@@ -850,6 +830,8 @@ func TestSurveyor_ObservationsWatcher(t *testing.T) {
 		if err := os.WriteFile(obsPath, obsConfigJSON, 0600); err != nil {
 			t.Fatalf("Error writing observation config file: %s", err)
 		}
+
+		obsConfig.ID = obsPath
 		expectedObservations[obsPath] = obsConfig
 		waitForMetricUpdate(t, om, expectedObservations)
 	})


### PR DESCRIPTION
- manage all service observations through `Surveyor.ServiceObservationManager()`
  - when Surveyor stops, remove all observations and file watchers
- add deprecation notices to `ServiceObsListener` and `NewServiceObservation`
  - `ServiceObsListener` should be unexported in a future release

public API is:

```
// ConfigMap returns a map of id:*ServiceObsConfig for all running observations.
func (om *ServiceObsManager) ConfigMap() map[string]*ServiceObsConfig

// Set creates or updates an observation
// if an observation exists with the same ID, it is updated
// otherwise, a new observation is created
func (om *ServiceObsManager) Set(config *ServiceObsConfig) error

// Delete deletes existing observations with provided ID
func (om *ServiceObsManager) Delete(id string) error
```