### PR TITLE
[ADDED] Server discovery without providing number of servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,31 +19,32 @@ Usage:
   nats-surveyor [flags]
 
 Flags:
-      --accounts                Export per account metrics
-  -a, --addr string             Network host to listen on. (default "0.0.0.0")
-      --config string           config file (default is ./nats-surveyor.yaml)
-  -c, --count int               Expected number of servers (default 1)
-      --creds string            Credentials File
-  -h, --help                    help for nats-surveyor
-      --http-pass string        Set the password for HTTP scrapes. NATS bcrypt supported.
-      --http-tlscacert string   Client certificate CA for verification (used with HTTPS).
-      --http-tlscert string     Server certificate file (Enables HTTPS).
-      --http-tlskey string      Private key for server certificate (used with HTTPS).
-      --http-user string        Enable basic auth and set user name for HTTP scrapes.
-      --jetstream string        Listen for JetStream Advisories based on config files in a directory.
-      --log-level string        Log level, one of: trace|debug|info|warn|error|fatal|panic (default "info")
-      --nkey string             Nkey Seed File
-      --observe string          Listen for observation statistics based on config files in a directory.
-      --password string         NATS user password
-  -p, --port int                Port to listen on. (default 7777)
-      --prefix string           Replace the default prefix for all the metrics.
-  -s, --servers string          NATS Cluster url(s) (default "nats://127.0.0.1:4222")
-      --timeout duration        Polling timeout (default 3s)
-      --tlscacert string        Client certificate CA on NATS connections.
-      --tlscert string          Client certificate file for NATS connections.
-      --tlskey string           Client private key for NATS connections.
-      --user string             NATS user name or token
-  -v, --version                 version for nats-surveyor
+      --accounts                            Export per account metrics
+  -a, --addr string                         Network host to listen on. (default "0.0.0.0")
+      --config string                       config file (default is ./nats-surveyor.yaml)
+  -c, --count int                           Expected number of servers (-1 for undefined). (default 1)
+      --creds string                        Credentials File
+  -h, --help                                help for nats-surveyor
+      --http-pass string                    Set the password for HTTP scrapes. NATS bcrypt supported.
+      --http-tlscacert string               Client certificate CA for verification (used with HTTPS).
+      --http-tlscert string                 Server certificate file (Enables HTTPS).
+      --http-tlskey string                  Private key for server certificate (used with HTTPS).
+      --http-user string                    Enable basic auth and set user name for HTTP scrapes.
+      --jetstream string                    Listen for JetStream Advisories based on config files in a directory.
+      --log-level string                    Log level, one of: trace|debug|info|warn|error|fatal|panic (default "info")
+      --nkey string                         Nkey Seed File
+      --observe string                      Listen for observation statistics based on config files in a directory.
+      --password string                     NATS user password
+  -p, --port int                            Port to listen on. (default 7777)
+      --prefix string                       Replace the default prefix for all the metrics.
+      --server-discovery-timeout duration   Maximum wait time between responses from servers during server discovery. Use in conjunction with -count=-1. (default 500ms)
+  -s, --servers string                      NATS Cluster url(s) (default "nats://127.0.0.1:4222")
+      --timeout duration                    Polling timeout (default 3s)
+      --tlscacert string                    Client certificate CA on NATS connections.
+      --tlscert string                      Client certificate file for NATS connections.
+      --tlskey string                       Client private key for NATS connections.
+      --user string                         NATS user name or token
+  -v, --version                             version for nats-surveyor
 ```
 
 At this time, NATS 2.0 System credentials are required for meaningful usage.

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -157,8 +157,12 @@ func init() {
 	_ = viper.BindPFlag("password", rootCmd.Flags().Lookup("password"))
 
 	// count
-	rootCmd.Flags().IntP("count", "c", 1, "Expected number of servers")
+	rootCmd.Flags().IntP("count", "c", 1, "Expected number of servers (-1 for undefined).")
 	_ = viper.BindPFlag("count", rootCmd.Flags().Lookup("count"))
+
+	// server-discovery-timeout
+	rootCmd.Flags().DurationP("server-discovery-timeout", "", 500*time.Millisecond, "Maximum wait time between responses from servers during server discovery. Use in conjunction with -count=-1.")
+	_ = viper.BindPFlag("server-discovery-timeout", rootCmd.Flags().Lookup("server-discovery-timeout"))
 
 	// timeout
 	rootCmd.Flags().Duration("timeout", surveyor.DefaultPollTimeout, "Polling timeout")
@@ -250,6 +254,7 @@ func getSurveyorOpts() *surveyor.Options {
 	opts.ObservationConfigDir = viper.GetString("observe")
 	opts.JetStreamConfigDir = viper.GetString("jetstream")
 	opts.Accounts = viper.GetBool("accounts")
+	opts.ServerResponseWait = viper.GetDuration("server-discovery-timeout")
 
 	logLevel, err := logrus.ParseLevel(viper.GetString("log-level"))
 	if err == nil {

--- a/docker-compose/docker-compose.yml
+++ b/docker-compose/docker-compose.yml
@@ -13,7 +13,7 @@ services:
       - $NATS_SURVEYOR_CREDS:/etc/surveyor/SYS.creds
       - ./observations:/observations
       - ./jetstream:/jetstream
-    command: --count ${NATS_SURVEYOR_SERVER_COUNT} -creds /etc/surveyor/SYS.creds -s "${NATS_SURVEYOR_SERVERS}" --accounts -observe /observations -jetstream /jetstream
+    command: --count ${NATS_SURVEYOR_SERVER_COUNT} --creds /etc/surveyor/SYS.creds -s "${NATS_SURVEYOR_SERVERS}" --accounts --observe /observations --jetstream /jetstream
     networks:
       - monitor-net
     labels:

--- a/surveyor/surveyor.go
+++ b/surveyor/surveyor.go
@@ -40,11 +40,12 @@ import (
 
 // Defaults
 var (
-	DefaultListenPort      = 7777
-	DefaultListenAddress   = "0.0.0.0"
-	DefaultURL             = nats.DefaultURL
-	DefaultExpectedServers = 1
-	DefaultPollTimeout     = time.Second * 3
+	DefaultListenPort         = 7777
+	DefaultListenAddress      = "0.0.0.0"
+	DefaultURL                = nats.DefaultURL
+	DefaultExpectedServers    = 1
+	DefaultPollTimeout        = time.Second * 3
+	DefaultServerResponseWait = 500 * time.Millisecond
 
 	// bcryptPrefix from nats-server
 	bcryptPrefix = "$2a$"
@@ -60,6 +61,7 @@ type Options struct {
 	NATSPassword         string
 	PollTimeout          time.Duration
 	ExpectedServers      int
+	ServerResponseWait   time.Duration
 	ListenAddress        string
 	ListenPort           int
 	CertFile             string
@@ -88,13 +90,14 @@ func GetDefaultOptions() *Options {
 	}
 
 	opts := &Options{
-		Name:            fmt.Sprintf("NATS_Surveyor - %s", hostname),
-		ListenAddress:   DefaultListenAddress,
-		ListenPort:      DefaultListenPort,
-		URLs:            DefaultURL,
-		PollTimeout:     DefaultPollTimeout,
-		ExpectedServers: DefaultExpectedServers,
-		Logger:          logrus.New(),
+		Name:               fmt.Sprintf("NATS_Surveyor - %s", hostname),
+		ListenAddress:      DefaultListenAddress,
+		ListenPort:         DefaultListenPort,
+		URLs:               DefaultURL,
+		PollTimeout:        DefaultPollTimeout,
+		ExpectedServers:    DefaultExpectedServers,
+		ServerResponseWait: DefaultServerResponseWait,
+		Logger:             logrus.New(),
 	}
 	return opts
 }
@@ -215,7 +218,7 @@ func (s *Surveyor) createStatszCollector() error {
 		s.logger.Debugln("Skipping per-account exports")
 	}
 
-	s.statzC = NewStatzCollector(nc, s.logger, s.opts.ExpectedServers, s.opts.PollTimeout, s.opts.Accounts, s.opts.ConstLabels)
+	s.statzC = NewStatzCollector(nc, s.logger, s.opts.ExpectedServers, s.opts.ServerResponseWait, s.opts.PollTimeout, s.opts.Accounts, s.opts.ConstLabels)
 	s.promRegistry.MustRegister(s.statzC)
 	return nil
 }


### PR DESCRIPTION
- `--count` now accepts `-1` as a value - when used, there is no expected value and the number of servers is calculated when polling
- When polling for `$SYS.REQ.SERVER.PING` and `--count==-1`, we are waiting for server responses until either polling timeout is reached or a duration defined in `--server-discovery-timeout` passes since last response (default 500ms)
- Fixed a bug which cased invalid value for `no_replies_count`