### PR TITLE
Update Dockerfile to expose port again

### DIFF
--- a/cicd/Dockerfile
+++ b/cicd/Dockerfile
@@ -38,4 +38,6 @@ COPY --from=assets entrypoint.sh /entrypoint.sh
 
 RUN ln -s /usr/local/bin/${GO_APP} /${GO_APP} && chmod +x /entrypoint.sh
 
+EXPOSE 7777
+
 ENTRYPOINT ["/entrypoint.sh"]


### PR DESCRIPTION
We missed adding this to the new dockerfile: https://github.com/nats-io/nats-surveyor/blob/main/Dockerfile#LL18