### PR TITLE
allow programatically setting nats opts

### DIFF
--- a/surveyor/jetstream_advisories.go
+++ b/surveyor/jetstream_advisories.go
@@ -14,7 +14,6 @@
 package surveyor
 
 import (
-	"crypto/tls"
 	"encoding/json"
 	"fmt"
 	"io/fs"
@@ -246,10 +245,6 @@ type JSAdvisoryConfig struct {
 	TLSCA       string `json:"tls_ca"`
 	TLSCert     string `json:"tls_cert"`
 	TLSKey      string `json:"tls_key"`
-
-	// tls.Config cannot be provided in observation config file,
-	// only programmatically
-	TLSConfig *tls.Config `json:"-"`
 }
 
 // Validate is used to validate a JSAdvisoryConfig
@@ -279,7 +274,6 @@ func (o *JSAdvisoryConfig) copy() *JSAdvisoryConfig {
 		return nil
 	}
 	cp := *o
-	cp.TLSConfig = o.TLSConfig.Clone()
 	return &cp
 }
 
@@ -343,7 +337,6 @@ func (o *jsAdvisoryListener) natsContext() *natsContext {
 		TLSCA:       o.config.TLSCA,
 		TLSCert:     o.config.TLSCert,
 		TLSKey:      o.config.TLSKey,
-		TLSConfig:   o.config.TLSConfig,
 	}
 
 	return natsCtx

--- a/surveyor/observation.go
+++ b/surveyor/observation.go
@@ -14,7 +14,6 @@
 package surveyor
 
 import (
-	"crypto/tls"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -136,10 +135,6 @@ type ServiceObsConfig struct {
 	TLSCA       string `json:"tls_ca"`
 	TLSCert     string `json:"tls_cert"`
 	TLSKey      string `json:"tls_key"`
-
-	// tls.Config cannot be provided in observation config file,
-	// only programmatically
-	TLSConfig *tls.Config `json:"-"`
 }
 
 // Validate is used to validate a ServiceObsConfig
@@ -173,7 +168,6 @@ func (o *ServiceObsConfig) copy() *ServiceObsConfig {
 		return nil
 	}
 	cp := *o
-	cp.TLSConfig = o.TLSConfig.Clone()
 	return &cp
 }
 
@@ -236,7 +230,6 @@ func (o *serviceObsListener) natsContext() *natsContext {
 		TLSCA:       o.config.TLSCA,
 		TLSCert:     o.config.TLSCert,
 		TLSKey:      o.config.TLSKey,
-		TLSConfig:   o.config.TLSConfig,
 	}
 
 	// legacy Credentials field

--- a/surveyor/surveyor_test.go
+++ b/surveyor/surveyor_test.go
@@ -435,7 +435,7 @@ func TestSurveyor_ClientTLS(t *testing.T) {
 
 		opts := getTestOptions()
 		opts.URLs = "127.0.0.1:4223"
-		opts.TLSConfig = tlsConfig
+		opts.NATSOpts = []nats.Option{nats.Secure(tlsConfig)}
 
 		s, err := NewSurveyor(opts)
 		if err != nil {
@@ -447,27 +447,6 @@ func TestSurveyor_ClientTLS(t *testing.T) {
 		defer s.Stop()
 
 		pollAndCheckDefault(t, "nats_core_mem_bytes")
-	})
-	t.Run("error passing both tls config and files", func(t *testing.T) {
-		tlsConfig, err := parseTLSConfig(clientCert, clientKey, caCertFile)
-		if err != nil {
-			t.Fatalf("Error parsing TLS config: %s", err)
-		}
-
-		opts := getTestOptions()
-		opts.URLs = "127.0.0.1:4223"
-		opts.CaFile = caCertFile
-		opts.CertFile = clientCert
-		opts.KeyFile = clientKey
-		opts.TLSConfig = tlsConfig
-
-		s, err := NewSurveyor(opts)
-		if err != nil {
-			t.Fatalf("couldn't create surveyor: %v", err)
-		}
-		if err = s.Start(); err == nil || !strings.Contains(err.Error(), "both TLS certificate file and tls.Config cannot be provided") {
-			t.Fatalf("start error: %v", err)
-		}
 	})
 }
 


### PR DESCRIPTION
- Adds `NATSOpts []nats.Option` to Surveyor config for library usage
- Removes programmatic `*tls.Config` in favor of `nats.Secure(tlsConfig)` - this is an unreleased change anyways so shouldn't be a problem