### PR TITLE
Add HTTP Shutdown Timeout

### DIFF
--- a/surveyor/conn_pool_test.go
+++ b/surveyor/conn_pool_test.go
@@ -13,6 +13,8 @@ import (
 )
 
 func TestConnPool(t *testing.T) {
+	t.Parallel()
+
 	s := natsservertest.RunRandClientPortServer()
 	defer s.Shutdown()
 	o1 := &natsContext{

--- a/surveyor/surveyor.go
+++ b/surveyor/surveyor.go
@@ -497,7 +497,9 @@ func (s *Surveyor) Stop() {
 	}
 
 	if s.httpServer != nil {
-		_ = s.httpServer.Shutdown(context.Background())
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+		_ = s.httpServer.Shutdown(ctx)
 		s.httpServer = nil
 	}
 

--- a/surveyor/surveyor_test.go
+++ b/surveyor/surveyor_test.go
@@ -82,7 +82,7 @@ func getTestOptions() *Options {
 
 // PollSurveyorEndpoint polls a surveyor endpoint for data
 func PollSurveyorEndpoint(t *testing.T, url string, secure bool, expectedRc int) (string, error) {
-	// t.Helper()
+	t.Helper()
 	var resp *http.Response
 	var err error
 

--- a/surveyor/surveyor_test.go
+++ b/surveyor/surveyor_test.go
@@ -45,7 +45,7 @@ func httpGetSecure(url string) (*http.Response, error) {
 		return nil, err
 	}
 	transport := &http.Transport{TLSClientConfig: tlsConfig}
-	httpClient := &http.Client{Transport: transport, Timeout: 30 * time.Second}
+	httpClient := &http.Client{Transport: transport, Timeout: 3 * time.Second}
 	return httpClient.Get(url)
 }
 
@@ -70,7 +70,7 @@ func parseTLSConfig(certFile, keyFile, caFile string) (*tls.Config, error) {
 }
 
 func httpGet(url string) (*http.Response, error) {
-	httpClient := &http.Client{Timeout: 30 * time.Second}
+	httpClient := &http.Client{Timeout: 3 * time.Second}
 	return httpClient.Get(url)
 }
 
@@ -82,7 +82,7 @@ func getTestOptions() *Options {
 
 // PollSurveyorEndpoint polls a surveyor endpoint for data
 func PollSurveyorEndpoint(t *testing.T, url string, secure bool, expectedRc int) (string, error) {
-	t.Helper()
+	// t.Helper()
 	var resp *http.Response
 	var err error
 


### PR DESCRIPTION
Adds a timeout to the context used to shutdown the scraper server.

This does NOT fix the intermittent failure of `TestSurveyor_HTTPS` but will surface the error and allow the tests to complete.