### PR TITLE
Add per-account tiered storage calculation

### DIFF
--- a/surveyor/collector_statz.go
+++ b/surveyor/collector_statz.go
@@ -89,22 +89,24 @@ type statzDescs struct {
 	JetstreamClusterRaftGroupReplicaOffline *prometheus.Desc
 
 	// Account scope metrics
-	accCount                    *prometheus.Desc
-	accConnCount                *prometheus.Desc
-	accLeafCount                *prometheus.Desc
-	accSubCount                 *prometheus.Desc
-	accBytesSent                *prometheus.Desc
-	accBytesRecv                *prometheus.Desc
-	accMsgsSent                 *prometheus.Desc
-	accMsgsRecv                 *prometheus.Desc
-	accJetstreamEnabled         *prometheus.Desc
-	accJetstreamMemoryUsed      *prometheus.Desc
-	accJetstreamStorageUsed     *prometheus.Desc
-	accJetstreamMemoryReserved  *prometheus.Desc
-	accJetstreamStorageReserved *prometheus.Desc
-	accJetstreamStreamCount     *prometheus.Desc
-	accJetstreamConsumerCount   *prometheus.Desc
-	accJetstreamReplicaCount    *prometheus.Desc
+	accCount                      *prometheus.Desc
+	accConnCount                  *prometheus.Desc
+	accLeafCount                  *prometheus.Desc
+	accSubCount                   *prometheus.Desc
+	accBytesSent                  *prometheus.Desc
+	accBytesRecv                  *prometheus.Desc
+	accMsgsSent                   *prometheus.Desc
+	accMsgsRecv                   *prometheus.Desc
+	accJetstreamEnabled           *prometheus.Desc
+	accJetstreamMemoryUsed        *prometheus.Desc
+	accJetstreamStorageUsed       *prometheus.Desc
+	accJetstreamTieredMemoryUsed  *prometheus.Desc
+	accJetstreamTieredStorageUsed *prometheus.Desc
+	accJetstreamMemoryReserved    *prometheus.Desc
+	accJetstreamStorageReserved   *prometheus.Desc
+	accJetstreamStreamCount       *prometheus.Desc
+	accJetstreamConsumerCount     *prometheus.Desc
+	accJetstreamReplicaCount      *prometheus.Desc
 }
 
 // StatzCollector collects statz from a server deployment
@@ -157,13 +159,15 @@ type accountStats struct {
 	msgsSent  float64
 	msgsRecv  float64
 
-	jetstreamEnabled         float64
-	jetstreamMemoryUsed      float64
-	jetstreamStorageUsed     float64
-	jetstreamMemoryReserved  float64
-	jetstreamStorageReserved float64
-	jetstreamStreamCount     float64
-	jetstreamStreams         []streamAccountStats
+	jetstreamEnabled           float64
+	jetstreamMemoryUsed        float64
+	jetstreamStorageUsed       float64
+	jetstreamTieredMemoryUsed  map[int]float64
+	jetstreamTieredStorageUsed map[int]float64
+	jetstreamMemoryReserved    float64
+	jetstreamStorageReserved   float64
+	jetstreamStreamCount       float64
+	jetstreamStreams           []streamAccountStats
 }
 
 type streamAccountStats struct {
@@ -306,6 +310,8 @@ func (sc *StatzCollector) buildDescs() {
 		sc.descs.accJetstreamEnabled = newPromDesc("account_jetstream_enabled", "Whether JetStream is enabled or not for this account", accLabel)
 		sc.descs.accJetstreamMemoryUsed = newPromDesc("account_jetstream_memory_used", "The number of bytes used by JetStream memory", accLabel)
 		sc.descs.accJetstreamStorageUsed = newPromDesc("account_jetstream_storage_used", "The number of bytes used by JetStream storage", accLabel)
+		sc.descs.accJetstreamTieredMemoryUsed = newPromDesc("account_jetstream_tiered_memory_used", "The number of bytes used by JetStream memory tier", append(accLabel, "tier"))
+		sc.descs.accJetstreamTieredStorageUsed = newPromDesc("account_jetstream_tiered_storage_used", "The number of bytes used by JetStream storage tier", append(accLabel, "tier"))
 		sc.descs.accJetstreamMemoryReserved = newPromDesc("account_jetstream_memory_reserved", "The number of bytes reserved by JetStream memory", accLabel)
 		sc.descs.accJetstreamStorageReserved = newPromDesc("account_jetstream_storage_reserved", "The number of bytes reserved by JetStream storage", accLabel)
 		sc.descs.accJetstreamStreamCount = newPromDesc("account_jetstream_stream_count", "The number of streams in this account", accLabel)
@@ -557,6 +563,8 @@ func (sc *StatzCollector) pollAccountInfo() error {
 		sts.jetstreamEnabled = 1.0
 		sts.jetstreamMemoryUsed = float64(jsInfo.Memory)
 		sts.jetstreamStorageUsed = float64(jsInfo.Store)
+		sts.jetstreamTieredMemoryUsed = make(map[int]float64)
+		sts.jetstreamTieredStorageUsed = make(map[int]float64)
 		sts.jetstreamMemoryReserved = float64(jsInfo.ReservedMemory)
 		sts.jetstreamStorageReserved = float64(jsInfo.ReservedStore)
 
@@ -567,6 +575,24 @@ func (sc *StatzCollector) pollAccountInfo() error {
 				consumerCount: float64(len(stream.Consumer)),
 				replicaCount:  float64(stream.Config.Replicas),
 			})
+
+			// computed tiered storage usage
+			// todo: figure out if we need to multiply size * replicas here
+			// size := float64(stream.State.Bytes * uint64(stream.Config.Replicas))
+			size := float64(stream.State.Bytes)
+			if stream.Config.Storage == server.MemoryStorage {
+				if _, ok = sts.jetstreamTieredMemoryUsed[stream.Config.Replicas]; ok {
+					sts.jetstreamTieredMemoryUsed[stream.Config.Replicas] += size
+				} else {
+					sts.jetstreamTieredMemoryUsed[stream.Config.Replicas] = size
+				}
+			} else if stream.Config.Storage == server.FileStorage {
+				if _, ok = sts.jetstreamTieredStorageUsed[stream.Config.Replicas]; ok {
+					sts.jetstreamTieredStorageUsed[stream.Config.Replicas] += size
+				} else {
+					sts.jetstreamTieredStorageUsed[stream.Config.Replicas] = size
+				}
+			}
 		}
 		accStats[jsInfo.Id] = sts
 	}
@@ -992,6 +1018,12 @@ func (sc *StatzCollector) Collect(ch chan<- prometheus.Metric) {
 			ch <- newGaugeMetric(sc.descs.accJetstreamEnabled, stat.jetstreamEnabled, id)
 			ch <- newGaugeMetric(sc.descs.accJetstreamMemoryUsed, stat.jetstreamMemoryUsed, id)
 			ch <- newGaugeMetric(sc.descs.accJetstreamStorageUsed, stat.jetstreamStorageUsed, id)
+			for tier, size := range stat.jetstreamTieredMemoryUsed {
+				ch <- newGaugeMetric(sc.descs.accJetstreamTieredMemoryUsed, size, append(id, fmt.Sprintf("r%d", tier)))
+			}
+			for tier, size := range stat.jetstreamTieredStorageUsed {
+				ch <- newGaugeMetric(sc.descs.accJetstreamTieredStorageUsed, size, append(id, fmt.Sprintf("r%d", tier)))
+			}
 			ch <- newGaugeMetric(sc.descs.accJetstreamMemoryReserved, stat.jetstreamMemoryReserved, id)
 			ch <- newGaugeMetric(sc.descs.accJetstreamStorageReserved, stat.jetstreamStorageReserved, id)
 

--- a/surveyor/surveyor_test.go
+++ b/surveyor/surveyor_test.go
@@ -250,6 +250,8 @@ func TestSurveyor_Account(t *testing.T) {
 		"nats_core_account_msgs_recv",
 		"nats_core_account_msgs_sent",
 		"nats_core_account_sub_count",
+		`nats_core_account_jetstream_tiered_storage_used{account="JS",tier="r1"}`,
+		`nats_core_account_jetstream_tiered_storage_used{account="JS",tier="r3"}`,
 	}
 	for _, m := range want {
 		if !strings.Contains(output, m) {


### PR DESCRIPTION
Adds a tiered storage calculation. Example:

```
nats_core_account_jetstream_tiered_storage_used{account="JS",tier="r1"} 123
nats_core_account_jetstream_tiered_storage_used{account="JS",tier="r3"} 456
```