### PR TITLE
Update CI

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,24 @@
+version: 2
+updates:
+  # version updates: enabled
+  # security updates: enabled
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "docker"
+    directory: "cicd"
+    schedule:
+      interval: "daily"
+    ignore:
+      - dependency-name: "golang"
+        update-types: ["version-update:semver-major"]
+
+  # version updates: disabled
+  # security updates: enabled
+  # https://docs.github.com/en/code-security/dependabot/dependabot-security-updates/configuring-dependabot-security-updates#overriding-the-default-behavior-with-a-configuration-file
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 0

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -11,6 +11,7 @@ release:
 
 builds:
   - main: .
+    id: nats-surveyor
     binary: nats-surveyor
     ldflags:
       - "-s -w -X github.com/nats-io/nats-surveyor/cmd.Version={{ .Tag }}"

--- a/cicd/Dockerfile
+++ b/cicd/Dockerfile
@@ -1,7 +1,5 @@
-#syntax=docker/dockerfile-upstream:1.4
-ARG GO_APP
-
-FROM base as deps
+#syntax=docker/dockerfile-upstream:1.6
+FROM goreleaser as build
 
 ARG GO_APP
 
@@ -11,28 +9,29 @@ ARG TARGETVARIANT
 
 RUN mkdir -p /go/bin /go/src
 
-COPY --from=build /go/src/dist /go/src/dist
+WORKDIR /go/src
 
 RUN <<EOT
   set -e 
-  apk add --no-cache ca-certificates jq
-  if [[ ${TARGETARCH} == "arm" ]]; then VARIANT=$(echo ${TARGETVARIANT} | sed 's/^v//'); fi
+  GORELEASER_DIST_DIR="/go/src/dist"
+
+  if [ "${TARGETARCH}" = "arm" ]; then VARIANT="$(echo "${TARGETVARIANT}" | sed 's/^v//')"; fi
   BIN_PATH=$(jq -r ".[] |select(.type   == \"Binary\" and \
-                                .name   == \"${GO_APP}\" and \
                                 .goos   == \"${TARGETOS}\" and \
                                 .goarch == \"${TARGETARCH}\" and \
-                                (.goarm == \"${VARIANT}\" or .goarm == null)) | .path" < /go/src/dist/artifacts.json)
+                                (.goarm == \"${VARIANT}\" or .goarm == null) and \
+                                .extra.ID == \"${GO_APP}\") | .path" < "${GORELEASER_DIST_DIR}/artifacts.json")
   cp ${BIN_PATH} /go/bin
 EOT
 
-FROM base
+FROM alpine:3.18.4
 
 ARG GO_APP
 ENV GO_APP ${GO_APP}
 
-COPY --from=deps --chmod=755 /go/bin/${GO_APP} /usr/local/bin/${GO_APP}
+COPY --from=build --chmod=755 /go/bin/${GO_APP} /usr/local/bin/${GO_APP}
 
-COPY --from=deps /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
+COPY --from=build /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 
 COPY --from=assets entrypoint.sh /entrypoint.sh
 

--- a/cicd/Dockerfile_goreleaser
+++ b/cicd/Dockerfile_goreleaser
@@ -1,17 +1,43 @@
-#syntax=docker/dockerfile-upstream:1.4
-FROM --platform=$BUILDPLATFORM goreleaser
+#syntax=docker/dockerfile-upstream:1.6
+FROM --platform=$BUILDPLATFORM golang:1.21.4-bullseye
 
 ARG CI
 ARG GITHUB_TOKEN
+ARG GORELEASER_KEY
+ENV GORELEASER_KEY=$GORELEASER_KEY
 
 COPY --from=src . /go/src
 
+WORKDIR /go/src
+
 RUN <<EOT
   set -e
-  cd /go/src
-  FLAGS="--rm-dist"
-  if [[ -z ${GITHUB_TOKEN} ]]; then
-    if [[ ${CI} != "true" ]]; then FLAGS="${FLAGS} --skip-validate --single-target"; fi
+
+  echo 'deb [trusted=yes] https://repo.goreleaser.com/apt/ /' > /etc/apt/sources.list.d/goreleaser.list
+  apt-key adv --keyserver keyserver.ubuntu.com --recv-key C99B11DEB97541F0
+
+  curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg > /usr/share/keyrings/githubcli-archive-keyring.gpg
+  echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" > /etc/apt/sources.list.d/github-cli.list
+
+  GORELEASER_DEB="goreleaser"
+  if [ -n "${GORELEASER_KEY}" ]; then
+      GORELEASER_DEB="goreleaser-pro"
+  fi
+
+  apt-get update
+  apt-get install -y \
+    gh \
+    jq \
+    "${GORELEASER_DEB}"
+  rm -rf /var/lib/apt/lists/*
+EOT
+
+RUN <<EOT
+  set -e
+  FLAGS="--clean"
+
+  if [ -z ${GITHUB_TOKEN} ]; then
+    if [ ${CI} != "true" ]; then FLAGS="${FLAGS} --skip-validate --single-target"; fi
     goreleaser build ${FLAGS}
   else
     goreleaser release ${FLAGS}

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -15,14 +15,6 @@ variable CI {
   default = false
 }
 
-variable image_base {
-  default = "docker-image://alpine:3.17.1"
-}
-
-variable image_goreleaser {
-  default = "docker-image://goreleaser/goreleaser:v1.22.1"
-}
-
 ###################
 ### Functions
 ###################
@@ -58,7 +50,6 @@ group "default" {
 
 target "goreleaser" {
   contexts = {
-    goreleaser = image_goreleaser
     src = "."
   }
   args = {
@@ -70,9 +61,8 @@ target "goreleaser" {
 
 target "nats-surveyor" {
   contexts = {
-    base    = image_base
-    build   = "target:goreleaser"
-    assets  = "cicd/assets"
+    assets     = "cicd/assets"
+    goreleaser = "target:goreleaser"
   }
   args = {
     GO_APP = "nats-surveyor"

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/nats-io/nats-surveyor
 
-go 1.20
+go 1.21
 
 require (
 	github.com/antonfisher/nested-logrus-formatter v1.3.1


### PR DESCRIPTION
- Changed goreleaser setup to add goreleaser binary to base golang image to allow better control of go versioning
- Replaced deprecated flag
- Added ability to use goreleaser-pro if key is set
- Added dependabot config
- Moved base images into Dockerfiles to allow dependabot tracking
- Fixed issue with goreleaser changing their `dist` path from absolute to relative