### PR TITLE
use reflect.DeepEqual for advisory/observation config equality

### DIFF
--- a/surveyor/jetstream_advisories.go
+++ b/surveyor/jetstream_advisories.go
@@ -19,6 +19,7 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"reflect"
 	"regexp"
 	"strings"
 	"sync"
@@ -665,7 +666,7 @@ func (am *JSAdvisoryManager) Set(config *JSAdvisoryConfig) error {
 	existingAdv, found := am.listenerMap[config.ID]
 	am.Unlock()
 
-	if found && *config == *existingAdv.config {
+	if found && reflect.DeepEqual(config, existingAdv.config) {
 		return nil
 	}
 

--- a/surveyor/observation.go
+++ b/surveyor/observation.go
@@ -20,6 +20,7 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strconv"
 	"strings"
 	"sync"
@@ -468,7 +469,7 @@ func (om *ServiceObsManager) Set(config *ServiceObsConfig) error {
 	existingObs, found := om.listenerMap[config.ID]
 	om.Unlock()
 
-	if found && *config == *existingObs.config {
+	if found && reflect.DeepEqual(config, existingObs.config) {
 		return nil
 	}
 


### PR DESCRIPTION
Struct equality is no longer guaranteed to work ever since `*ServiceObservationExternalAccountConfig` was added to `ServiceObsConfig`, and `*JSAdvisoriesExternalAccountConfig` was added to `JSAdvisoryConfig`

Use `reflect.DeepEqual` instead, so that pointer types are de-referenced for equality checks