### PR TITLE
use counters for msgs/bytes sent/recv

### DIFF
--- a/surveyor/collector_statz.go
+++ b/surveyor/collector_statz.go
@@ -759,6 +759,11 @@ func (sc *StatzCollector) getAccStatz(nc *nats.Conn) (map[string][]*accStat, err
 	accStats := make(map[string][]*accStat)
 	for _, statz := range res {
 		for _, acc := range statz.Data.Accounts {
+			// always skip if account has never connected
+			if acc.TotalConns == 0 {
+				continue
+			}
+
 			// optimization to stop reporting a server/account pair
 			// when a server is continuously reporting 0 conns for that account
 			zeroConnKey := statz.Server.ID + ":" + acc.Account

--- a/surveyor/collector_statz.go
+++ b/surveyor/collector_statz.go
@@ -254,7 +254,7 @@ func (sc *StatzCollector) buildDescs() {
 
 	// A unlabelled description for the up/down
 	sc.natsUp = prometheus.NewDesc(prometheus.BuildFQName("nats", "core", "nats_up"),
-		"1 if connected to NATS, 0 otherwise.  A counter.", nil, sc.constLabels)
+		"1 if connected to NATS, 0 otherwise.  A gauge.", nil, sc.constLabels)
 
 	sc.descs.Info = newPromDesc("info", "General Server information Summary gauge", sc.serverInfoLabels)
 	sc.descs.Start = newPromDesc("start_time", "Server start time gauge", sc.serverLabels)
@@ -948,7 +948,7 @@ func (sc *StatzCollector) Collect(ch chan<- prometheus.Metric) {
 		if err := sc.poll(); err != nil {
 			sc.logger.Warnf("Error polling NATS server: %v", err)
 			sc.pollErrCnt.WithLabelValues().Inc()
-			metrics.newCounterMetric(sc.natsUp, 0, nil)
+			metrics.newGaugeMetric(sc.natsUp, 0, nil)
 			return metrics.metrics, nil
 		}
 
@@ -956,7 +956,7 @@ func (sc *StatzCollector) Collect(ch chan<- prometheus.Metric) {
 		sc.Lock()
 		defer sc.Unlock()
 
-		metrics.newCounterMetric(sc.natsUp, 1, nil)
+		metrics.newGaugeMetric(sc.natsUp, 1, nil)
 		sc.surveyedCnt.WithLabelValues().Set(0)
 
 		for _, sm := range sc.stats {

--- a/surveyor/surveyor_test.go
+++ b/surveyor/surveyor_test.go
@@ -245,16 +245,18 @@ func TestSurveyor_Account(t *testing.T) {
 	}
 
 	want := []string{
-		"nats_core_account_bytes_recv",
-		"nats_core_account_bytes_sent",
-		"nats_core_account_conn_count",
 		"nats_core_account_count",
+		"nats_core_account_conn_count",
+		"nats_core_account_total_conn_count",
+		"nats_core_account_leaf_count",
+		"nats_core_account_sub_count",
+		"nats_core_account_slow_consumer_count",
+		"nats_core_account_bytes_sent",
+		"nats_core_account_bytes_recv",
+		"nats_core_account_msgs_sent",
+		"nats_core_account_msgs_recv",
 		"nats_core_account_jetstream_enabled",
 		"nats_core_account_jetstream_stream_count",
-		"nats_core_account_leaf_count",
-		"nats_core_account_msgs_recv",
-		"nats_core_account_msgs_sent",
-		"nats_core_account_sub_count",
 	}
 	for _, m := range want {
 		if !strings.Contains(output, m) {


### PR DESCRIPTION
Resolves #189 

Corrects Total Connections and Bytes Sent/Recv to be counters instead of gauges

Also fixes Account Counters to use their own time-series per server, as counters must not be aggregated