### PR TITLE
Fix linter issues and use const version of golangci-lint

### DIFF
--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -9,7 +9,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go: [ '1.22' ]
+        go: [ '1.23' ]
         os: [ ubuntu-latest, macOS-latest ]
     runs-on: ${{matrix.os}}
     steps:
@@ -19,29 +19,15 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: ${{matrix.go}}
-      - name: Install deps
-        shell: bash --noprofile --norc -x -eo pipefail {0}
-        run: |
-          cd /tmp
-          go install -v github.com/golangci/golangci-lint/cmd/golangci-lint@latest
-      - name: Lint
+      - name: go vet
         shell: bash --noprofile --norc -x -eo pipefail {0}
         run: |
           go mod tidy
           go vet ./...
-          golangci-lint run \
-             --no-config --exclude-use-default=false --max-same-issues=0 \
-               --disable errcheck \
-               --disable gocritic \
-               --enable stylecheck \
-               --enable unconvert \
-               --enable gofmt \
-               --enable misspell \
-               --enable unparam \
-               --enable nakedret \
-               --enable prealloc \
-               --enable misspell \
-               ./...
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v6
+        with:
+          version: v1.60
 
       - name: Run tests
         shell: bash --noprofile --norc -x -eo pipefail {0}

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,17 @@
+issues:
+  exclude-use-default: false
+  max-same-issues: 0
+
+linters:
+  enable:
+    - stylecheck
+    - unconvert
+    - gofmt
+    - misspell
+    - unparam
+    - nakedret
+    - prealloc
+    - misspell
+  disable:
+    - errcheck
+    - gocritic

--- a/surveyor/jetstream_advisories.go
+++ b/surveyor/jetstream_advisories.go
@@ -283,47 +283,47 @@ func (o *JSAdvisoryConfig) Validate() error {
 		return fmt.Errorf("js advisory config cannot be nil")
 	}
 
-	var errs []string
+	var errs []error
 	if o.ID == "" {
-		errs = append(errs, "id is required")
+		errs = append(errs, fmt.Errorf("id is required"))
 	}
 
 	if o.AccountName == "" {
-		errs = append(errs, "name is required")
+		errs = append(errs, fmt.Errorf("name is required"))
 	}
 
 	if o.ExternalAccountConfig != nil {
 		if o.ExternalAccountConfig.MetricsSubject == "" {
-			errs = append(errs, "external_account_config.metrics_subject is required when importing metrics from external accounts")
+			errs = append(errs, fmt.Errorf("external_account_config.metrics_subject is required when importing metrics from external accounts"))
 		}
 		metricsTokens := strings.Split(o.ExternalAccountConfig.MetricsSubject, ".")
 		switch {
 		case o.ExternalAccountConfig.MetricsAccountTokenPosition <= 0:
-			errs = append(errs, "external_account_config.metrics_account_token_position is required when importing metrics from external accounts")
+			errs = append(errs, fmt.Errorf("external_account_config.metrics_account_token_position is required when importing metrics from external accounts"))
 		case o.ExternalAccountConfig.MetricsAccountTokenPosition > len(metricsTokens):
-			errs = append(errs, "external_account_config.metrics_account_token_position is greater than the number of tokens in external_account_config.metrics_subject")
+			errs = append(errs, fmt.Errorf("external_account_config.metrics_account_token_position is greater than the number of tokens in external_account_config.metrics_subject"))
 		case metricsTokens[o.ExternalAccountConfig.AdvisoryAccountTokenPosition-1] != "*":
-			errs = append(errs, "external_account_config.metrics_subject must have a wildcard token at the position specified by external_account_config.metrics_account_token_position")
+			errs = append(errs, fmt.Errorf("external_account_config.metrics_subject must have a wildcard token at the position specified by external_account_config.metrics_account_token_position"))
 		}
 
 		if o.ExternalAccountConfig.AdvisorySubject == "" {
-			errs = append(errs, "external_account_config.advisory_subject is required when importing advisories from external accounts")
+			errs = append(errs, fmt.Errorf("external_account_config.advisory_subject is required when importing advisories from external accounts"))
 		}
 		advisoryTokens := strings.Split(o.ExternalAccountConfig.AdvisorySubject, ".")
 		switch {
 		case o.ExternalAccountConfig.AdvisoryAccountTokenPosition <= 0:
-			errs = append(errs, "external_account_config.advisory_account_token_position is required when importing advisories from external accounts")
+			errs = append(errs, fmt.Errorf("external_account_config.advisory_account_token_position is required when importing advisories from external accounts"))
 		case o.ExternalAccountConfig.AdvisoryAccountTokenPosition > len(advisoryTokens):
-			errs = append(errs, "external_account_config.advisory_account_token_position is greater than the number of tokens in external_account_config.advisory_subject")
+			errs = append(errs, fmt.Errorf("external_account_config.advisory_account_token_position is greater than the number of tokens in external_account_config.advisory_subject"))
 		case advisoryTokens[o.ExternalAccountConfig.AdvisoryAccountTokenPosition-1] != "*":
-			errs = append(errs, "external_account_config.advisory_subject must have a wildcard token at the position specified by external_account_config.advisory_account_token_position")
+			errs = append(errs, fmt.Errorf("external_account_config.advisory_subject must have a wildcard token at the position specified by external_account_config.advisory_account_token_position"))
 		}
 	}
 	if len(errs) == 0 {
 		return nil
 	}
 
-	return errors.New(strings.Join(errs, ", "))
+	return errors.Join(errs...)
 }
 
 func (o *JSAdvisoryConfig) copy() *JSAdvisoryConfig {


### PR DESCRIPTION
This fixes an issue surfacing after updating golangci-lint. Switched to using a constant version of the tool to avoid such issues in the future.

Signed-off-by: Piotr Piotrowski [piotr@synadia.com](mailto:piotr@synadia.com)