### PR TITLE
Add gatewayz metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Usage:
 
 Flags:
       --accounts                            Export per account metrics
+      --gatewayz                            Export gateway metrics
   -a, --addr string                         Network host to listen on. (default "0.0.0.0")
       --config string                       config file (default is ./nats-surveyor.yaml)
   -c, --count int                           Expected number of servers (-1 for undefined). (default 1)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -237,7 +237,7 @@ func init() {
 	rootCmd.Flags().Bool("accounts", false, "Export per account metrics")
 	_ = viper.BindPFlag("accounts", rootCmd.Flags().Lookup("accounts"))
 
-	// gaewayz
+	// gatewayz
 	rootCmd.Flags().Bool("gatewayz", false, "Export gateway metrics")
 	_ = viper.BindPFlag("gatewayz", rootCmd.Flags().Lookup("gatewayz"))
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -73,6 +73,7 @@ func rootCmdArgs(args []string) []string {
 		"-prefix":          "--prefix",
 		"-observe":         "--observe",
 		"-jetstream":       "--jetstream",
+		"-gatewayz":        "--gatewayz",
 	}
 	newArgs := make([]string, 0)
 
@@ -236,6 +237,10 @@ func init() {
 	rootCmd.Flags().Bool("accounts", false, "Export per account metrics")
 	_ = viper.BindPFlag("accounts", rootCmd.Flags().Lookup("accounts"))
 
+	// gaewayz
+	rootCmd.Flags().Bool("gatewayz", false, "Export gateway metrics")
+	_ = viper.BindPFlag("gatewayz", rootCmd.Flags().Lookup("gatewayz"))
+
 	// log-level
 	rootCmd.Flags().String("log-level", "info", "Log level, one of: trace|debug|info|warn|error|fatal|panic")
 	_ = viper.BindPFlag("log-level", rootCmd.Flags().Lookup("log-level"))
@@ -269,6 +274,7 @@ func getSurveyorOpts() *surveyor.Options {
 	opts.ObservationConfigDir = viper.GetString("observe")
 	opts.JetStreamConfigDir = viper.GetString("jetstream")
 	opts.Accounts = viper.GetBool("accounts")
+	opts.Gatewayz = viper.GetBool("gatewayz")
 	opts.ServerResponseWait = viper.GetDuration("server-discovery-timeout")
 
 	logLevel, err := logrus.ParseLevel(viper.GetString("log-level"))

--- a/surveyor/collector_statz.go
+++ b/surveyor/collector_statz.go
@@ -1327,14 +1327,14 @@ func collectGatewayzMetrics(metrics *metricSlice, gwDescs *gatewayzDescs, rgwNam
 	if gw.IsConfigured {
 		isConfigured = 1
 	}
-	serverId := gwStat.Server.ID
+	serverID := gwStat.Server.ID
 	serverName := gwStat.Server.Name
 	gwName := gwStat.Data.Name
-	gwId := gw.Connection.Name
+	gwID := gw.Connection.Name
 	cid := strconv.FormatUint(gw.Connection.Cid, 10)
 
 	// server_id, server_name, gateway_name, remote_gateway_name, gateway_id, cid
-	labels := []string{serverId, serverName, gwName, rgwName, gwId, cid}
+	labels := []string{serverID, serverName, gwName, rgwName, gwID, cid}
 	uptime, _ := time.ParseDuration(gw.Connection.Uptime)
 	idle, _ := time.ParseDuration(gw.Connection.Idle)
 	rtt, _ := time.ParseDuration(gw.Connection.RTT)

--- a/surveyor/surveyor.go
+++ b/surveyor/surveyor.go
@@ -79,6 +79,7 @@ type Options struct {
 	ObservationConfigDir string
 	JetStreamConfigDir   string
 	Accounts             bool
+	Gatewayz             bool
 	Logger               *logrus.Logger    // not exposed by CLI
 	NATSOpts             []nats.Option     // not exposed by CLI
 	ConstLabels          prometheus.Labels // not exposed by CLI
@@ -200,7 +201,7 @@ func (s *Surveyor) createStatszCollector() error {
 		s.logger.Debugln("Skipping per-account exports")
 	}
 
-	s.statzC = NewStatzCollector(s.sysAcctPC.nc, s.logger, s.opts.ExpectedServers, s.opts.ServerResponseWait, s.opts.PollTimeout, s.opts.Accounts, s.opts.ConstLabels)
+	s.statzC = NewStatzCollector(s.sysAcctPC.nc, s.logger, s.opts.ExpectedServers, s.opts.ServerResponseWait, s.opts.PollTimeout, s.opts.Accounts, s.opts.Gatewayz, s.opts.ConstLabels)
 	return s.promRegistry.Register(s.statzC)
 }
 

--- a/surveyor/surveyor_test.go
+++ b/surveyor/surveyor_test.go
@@ -267,6 +267,60 @@ func TestSurveyor_Account(t *testing.T) {
 	}
 }
 
+func TestSurveyor_Gatewayz(t *testing.T) {
+	sc := st.NewSuperCluster(t)
+	defer sc.Shutdown()
+
+	opt := getTestOptions()
+	opt.Gatewayz = true
+	opt.ExpectedServers = 3
+	s, err := NewSurveyor(opt)
+	if err != nil {
+		t.Fatalf("couldn't create surveyor: %v", err)
+	}
+	if err = s.Start(); err != nil {
+		t.Fatalf("start error: %v", err)
+	}
+
+	defer s.Stop()
+
+	output, err := PollSurveyorEndpoint(t, "http://127.0.0.1:7777/metrics", false, http.StatusOK)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := []string{
+		"nats_core_gatewayz_inbound_gateway_configured",
+		"nats_core_gatewayz_inbound_gateway_conn_idle_seconds",
+		"nats_core_gatewayz_inbound_gateway_conn_in_bytes",
+		"nats_core_gatewayz_inbound_gateway_conn_in_msgs",
+		"nats_core_gatewayz_inbound_gateway_conn_last_activity_seconds",
+		"nats_core_gatewayz_inbound_gateway_conn_out_bytes",
+		"nats_core_gatewayz_inbound_gateway_conn_out_msgs",
+		"nats_core_gatewayz_inbound_gateway_conn_pending_bytes",
+		"nats_core_gatewayz_inbound_gateway_conn_rtt",
+		"nats_core_gatewayz_inbound_gateway_conn_subscriptions",
+		"nats_core_gatewayz_inbound_gateway_conn_uptime_seconds",
+		"nats_core_gatewayz_outbound_gateway_configured",
+		"nats_core_gatewayz_outbound_gateway_conn_idle_seconds",
+		"nats_core_gatewayz_outbound_gateway_conn_in_bytes",
+		"nats_core_gatewayz_outbound_gateway_conn_in_msgs",
+		"nats_core_gatewayz_outbound_gateway_conn_last_activity_seconds",
+		"nats_core_gatewayz_outbound_gateway_conn_out_bytes",
+		"nats_core_gatewayz_outbound_gateway_conn_out_msgs",
+		"nats_core_gatewayz_outbound_gateway_conn_pending_bytes",
+		"nats_core_gatewayz_outbound_gateway_conn_rtt",
+		"nats_core_gatewayz_outbound_gateway_conn_subscriptions",
+		"nats_core_gatewayz_outbound_gateway_conn_uptime_seconds",
+	}
+	for _, m := range want {
+		if !strings.Contains(output, m) {
+			t.Logf("output: %s", output)
+			t.Fatalf("missing: %s", m)
+		}
+	}
+}
+
 func TestSurveyor_AccountJetStreamAssets(t *testing.T) {
 	sc := st.NewJetStreamCluster(t)
 	defer sc.Shutdown()


### PR DESCRIPTION
Added `--gatewayz` flag to enable stats such as `pending_bytes` per gateway.

Signed-off-by: Ziya Suzen <ziya@synadia.com>