### PR TITLE
fix: require no arguments

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -36,6 +36,7 @@ var (
 	rootCmd = &cobra.Command{
 		Use:     "nats-surveyor",
 		Short:   "Prometheus exporter for NATS",
+		Args:    cobra.NoArgs,
 		RunE:    run,
 		Version: Version,
 	}


### PR DESCRIPTION
This command does not have positional args, so let's enforce it.

## Test plan:
### Before: 
Typo in args list, but command still runs, silently ignoring invalid input:
```
# go run . -c -1 timeout 10s
2025-04-10T16:19:27-07:00 [INFO] NATS_Surveyor - omenlaptop connected to NATS Deployment: 127.0.0.1:4222
2025-04-10T16:19:27-07:00 [INFO] Prometheus exporter listening at http://0.0.0.0:7777/metrics
^C
```

### After
```
# go run . -c -1 timeout 10s
Error: unknown command "timeout" for "nats-surveyor"
Usage:
  nats-surveyor [flags]

Flags:
      --accounts                            Export per account metrics
...
```
