### PR TITLE
Add jsz stream and consumer replicas metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Flags:
       --jetstream string                    Listen for JetStream Advisories based on config files in a directory.
       --accounts                            Export per account metrics
       --gatewayz                            Export gateway metrics
+      --jsz                                 Export jsz metrics
       --sys-req-prefix string               Subject prefix for system requests ($SYS.REQ) (default "$SYS.REQ")
       --log-level string                    Log level, one of: trace|debug|info|warn|error|fatal|panic (default "info")
       --config string                       config file (default is ./nats-surveyor.yaml)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -75,6 +75,7 @@ func rootCmdArgs(args []string) []string {
 		"-observe":         "--observe",
 		"-jetstream":       "--jetstream",
 		"-gatewayz":        "--gatewayz",
+		"-jsz":             "--jsz",
 	}
 	newArgs := make([]string, 0)
 
@@ -243,6 +244,10 @@ func init() {
 	rootCmd.Flags().Bool("gatewayz", false, "Export gateway metrics")
 	_ = viper.BindPFlag("gatewayz", rootCmd.Flags().Lookup("gatewayz"))
 
+	// jsz streams
+	rootCmd.Flags().String("jsz", "", "Export jsz metrics optionally, one of: all|streams|consumers")
+	_ = viper.BindPFlag("jsz", rootCmd.Flags().Lookup("jsz"))
+
 	// sys-req-prefix
 	rootCmd.Flags().String("sys-req-prefix", surveyor.DefaultSysReqPrefix, "Subject prefix for system requests ($SYS.REQ)")
 	_ = viper.BindPFlag("sys-req-prefix", rootCmd.Flags().Lookup("sys-req-prefix"))
@@ -283,6 +288,7 @@ func getSurveyorOpts() *surveyor.Options {
 	opts.JetStreamConfigDir = viper.GetString("jetstream")
 	opts.Accounts = viper.GetBool("accounts")
 	opts.Gatewayz = viper.GetBool("gatewayz")
+	opts.Jsz = viper.GetString("jsz")
 	opts.SysReqPrefix = viper.GetString("sys-req-prefix")
 	opts.ServerResponseWait = viper.GetDuration("server-discovery-timeout")
 

--- a/surveyor/surveyor.go
+++ b/surveyor/surveyor.go
@@ -81,6 +81,7 @@ type Options struct {
 	JetStreamConfigDir   string
 	Accounts             bool
 	Gatewayz             bool
+	Jsz                  string
 	SysReqPrefix         string
 	Logger               *logrus.Logger    // not exposed by CLI
 	Provider             ConnProvider      // not exposed by CLI
@@ -225,6 +226,7 @@ func (s *Surveyor) createStatszCollector() error {
 		s.opts.PollTimeout,
 		s.opts.Accounts,
 		s.opts.Gatewayz,
+		s.opts.Jsz,
 		s.opts.SysReqPrefix,
 		s.opts.ConstLabels,
 	)


### PR DESCRIPTION
This adds an `--jsz` option that enables tracking more metadata from the replica similar to how it currently works with the prometheus-exporter `--jsz` option. 
Possible values are `--jsz=all` for both streams and consumers data, and `--jsz=streams` to only capture streams state, skipping consumers. 

For streams, adding:

```
nats_stream_consumer_count
nats_stream_first_seq
nats_stream_last_seq
nats_stream_subject_count
nats_stream_total_bytes
nats_stream_total_messages
```

For consumers: 

```
nats_consumer_ack_floor_consumer_seq
nats_consumer_ack_floor_stream_seq
nats_consumer_delivered_consumer_seq
nats_consumer_delivered_stream_seq
nats_consumer_num_ack_pending
nats_consumer_num_pending
nats_consumer_num_redelivered
nats_consumer_num_waiting
```