### PR TITLE
More desriptive error message on 503: no responders available

### DIFF
--- a/surveyor/collector_statz.go
+++ b/surveyor/collector_statz.go
@@ -1808,6 +1808,10 @@ func requestMany(nc *nats.Conn, sc *StatzCollector, subject string, data []byte,
 
 // Performs JSON Unmarshal, decompressing snappy encoding if necessary
 func unmarshalMsg(msg *nats.Msg, v any) error {
+
+	if msg.Header.Get("Status") == "503" && len(msg.Data) == 0 {
+		return fmt.Errorf("Got a message with status 503: No responders available: %v", msg)
+	}
 	data := msg.Data
 
 	if msg.Header.Get("Content-Encoding") == "snappy" {


### PR DESCRIPTION
When the user incorrectly sets up the surveyor, e.g. with non-system account, the error message is confusing:

# Test plan:
## Before:
```
# go run .   --log-level=trace 
2025-05-15T12:59:01-07:00 [INFO] NATS_Surveyor - omenlaptop connected to NATS Deployment: 127.0.0.1:4222
2025-05-15T12:59:01-07:00 [DEBU] Skipping per-account exports
2025-05-15T12:59:01-07:00 [DEBU] skipping service observation startup, no directory configured
2025-05-15T12:59:01-07:00 [DEBU] skipping JetStream advisory startup, no directory configured
2025-05-15T12:59:01-07:00 [DEBU] No certificate file specified; using listener.
2025-05-15T12:59:01-07:00 [INFO] Prometheus exporter listening at http://0.0.0.0:7777/metrics
2025-05-15T12:59:02-07:00 [WARN] Error unmarshalling statz json: unexpected end of JSON input
2025-05-15T12:59:03-07:00 [WARN] Error unmarshalling statz json: unexpected end of JSON input

```

## After:
```
# go run .   --log-level=trace 
2025-05-15T12:57:25-07:00 [INFO] NATS_Surveyor - omenlaptop connected to NATS Deployment: 127.0.0.1:4222
2025-05-15T12:57:25-07:00 [DEBU] Skipping per-account exports
2025-05-15T12:57:25-07:00 [DEBU] skipping service observation startup, no directory configured
2025-05-15T12:57:25-07:00 [DEBU] skipping JetStream advisory startup, no directory configured
2025-05-15T12:57:25-07:00 [DEBU] No certificate file specified; using listener.
2025-05-15T12:57:25-07:00 [INFO] Prometheus exporter listening at http://0.0.0.0:7777/metrics
2025-05-15T12:57:27-07:00 [WARN] Error unmarshalling statz json: Got a message with status 503: No responders available: &{_INBOX.Q7kPCSQ1oCaE7r9KmOZDmr.hoSf7Jrk.1747339047362275805  map[Status:[503]] [] 0xc000130690 <nil> 74 <nil> 0}
```