### PR TITLE
sort list of filters in the help text

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -261,7 +261,7 @@ func init() {
 		enumflag.NewSlice(&jszFilters, "jsz-filter", surveyor.JszFilterIds, enumflag.EnumCaseInsensitive),
 		"jsz-filter",
 		fmt.Sprintf("Fetch selected jsz metrics only(comma separated list). Metrics: %s",
-			strings.Join(surveyor.JszFiltersToStringSlice(slices.Collect(maps.Keys(surveyor.JszFilterIds))), ",")),
+			strings.Join(surveyor.JszFiltersToStringSlice(slices.Sorted(maps.Keys(surveyor.JszFilterIds))), ",")),
 	)
 	_ = viper.BindPFlag("jsz-filter", rootCmd.Flags().Lookup("jsz-filter"))
 


### PR DESCRIPTION
This list should be sorted
```
# go run .     -h | grep jsz-filter
      --jsz-filter jsz-filter               Fetch selected jsz metrics only(comma separated list). Metrics: stream_total_messages,stream_total_bytes,stream_first_seq,stream_last_seq,stream_consumer_count,stream_subject_count,consumer_delivered_consumer_seq,consumer_delivered_stream_seq,consumer_ack_floor_consumer_seq,consumer_ack_floor_stream_seq,consumer_num_ack_pending,consumer_num_pending,consumer_num_redelivered,consumer_num_waiting (default [])
```
