### PR TITLE
Add account_name label to metrics missing this field

### DIFF
--- a/surveyor/collector_statz.go
+++ b/surveyor/collector_statz.go
@@ -216,7 +216,7 @@ type StatzCollector struct {
 }
 
 type accountStats struct {
-	accountID string
+	accountID   string
 	accountName string
 
 	stats []*accStat
@@ -815,9 +815,9 @@ func (sc *StatzCollector) pollAccountInfo() error {
 			accountName = stats[0].Data.Name
 		}
 		sts := &accountStats{
-			accountID: accID,
+			accountID:   accID,
 			accountName: accountName,
-			stats:     stats,
+			stats:       stats,
 		}
 
 		accStats[accID] = sts
@@ -829,7 +829,7 @@ func (sc *StatzCollector) pollAccountInfo() error {
 		// If no account stats returned, still report JS metrics
 		if !ok {
 			sts = &accountStats{
-				accountID: accID,
+				accountID:   accID,
 				accountName: accDetail.Name,
 			}
 		}

--- a/surveyor/surveyor_test.go
+++ b/surveyor/surveyor_test.go
@@ -387,14 +387,14 @@ func TestSurveyor_AccountJetStreamAssets(t *testing.T) {
 		regexp.MustCompile(`nats_core_account_conn_count`),
 		regexp.MustCompile(`nats_core_account_count`),
 		regexp.MustCompile(`nats_core_account_jetstream_enabled`),
-		regexp.MustCompile(`nats_core_account_jetstream_stream_count\{account="JS"} 10`),
-		regexp.MustCompile(`nats_core_account_jetstream_consumer_count\{account="JS",raft_group="[^"]+",stream="repl1"} 5`),
-		regexp.MustCompile(`nats_core_account_jetstream_consumer_count\{account="JS",raft_group="[^"]+",stream="repl2"} 5`),
-		regexp.MustCompile(`nats_core_account_jetstream_consumer_count\{account="JS",raft_group="[^"]+",stream="single1"} 5`),
-		regexp.MustCompile(`nats_core_account_jetstream_tiered_storage_used\{account="JS",tier="R1"}`),
-		regexp.MustCompile(`nats_core_account_jetstream_tiered_storage_used\{account="JS",tier="R3"}`),
-		regexp.MustCompile(`nats_core_account_jetstream_tiered_storage_reserved\{account="JS",tier="R1"}`),
-		regexp.MustCompile(`nats_core_account_jetstream_tiered_storage_reserved\{account="JS",tier="R3"}`),
+		regexp.MustCompile(`nats_core_account_jetstream_stream_count\{account="JS",account_name="[^"]+"} 10`),
+		regexp.MustCompile(`nats_core_account_jetstream_consumer_count\{account="JS",account_name="[^"]+",raft_group="[^"]+",stream="repl1"} 5`),
+		regexp.MustCompile(`nats_core_account_jetstream_consumer_count\{account="JS",account_name="[^"]+",raft_group="[^"]+",stream="repl2"} 5`),
+		regexp.MustCompile(`nats_core_account_jetstream_consumer_count\{account="JS",account_name="[^"]+",raft_group="[^"]+",stream="single1"} 5`),
+		regexp.MustCompile(`nats_core_account_jetstream_tiered_storage_used\{account="JS",account_name="[^"]+",tier="R1"}`),
+		regexp.MustCompile(`nats_core_account_jetstream_tiered_storage_used\{account="JS",account_name="[^"]+",tier="R3"}`),
+		regexp.MustCompile(`nats_core_account_jetstream_tiered_storage_reserved\{account="JS",account_name="[^"]+",tier="R1"}`),
+		regexp.MustCompile(`nats_core_account_jetstream_tiered_storage_reserved\{account="JS",account_name="[^"]+",tier="R3"}`),
 	}
 	for _, m := range want {
 		if !m.MatchString(output) {


### PR DESCRIPTION
While working with metrics from `nats-surveyor`, I encountered metrics that only had account ID but no account name. It's quite impractical to filter and work with account IDs, so this PR adds `account_name` to metrics where it was missing and makes sense.