### PR TITLE
Make `ServiceObsManager` and `JSAdvisoryManager` functions public

### DIFF
--- a/surveyor/jetstream_advisories.go
+++ b/surveyor/jetstream_advisories.go
@@ -607,8 +607,8 @@ type JSAdvisoryManager struct {
 	metrics     *JSAdvisoryMetrics
 }
 
-// newJetStreamAdvisoryManager creates a JSAdvisoryManager for managing JetStream advisories
-func newJetStreamAdvisoryManager(provider ConnProvider, logger *logrus.Logger, metrics *JSAdvisoryMetrics) *JSAdvisoryManager {
+// NewJetStreamAdvisoryManager creates a JSAdvisoryManager for managing JetStream advisories
+func NewJetStreamAdvisoryManager(provider ConnProvider, logger *logrus.Logger, metrics *JSAdvisoryMetrics) *JSAdvisoryManager {
 	return &JSAdvisoryManager{
 		provider: provider,
 		logger:   logger,
@@ -616,7 +616,7 @@ func newJetStreamAdvisoryManager(provider ConnProvider, logger *logrus.Logger, m
 	}
 }
 
-func (am *JSAdvisoryManager) start() {
+func (am *JSAdvisoryManager) Start() {
 	am.Lock()
 	defer am.Unlock()
 	if am.listenerMap != nil {
@@ -634,7 +634,7 @@ func (am *JSAdvisoryManager) IsRunning() bool {
 	return am.listenerMap != nil
 }
 
-func (am *JSAdvisoryManager) stop() {
+func (am *JSAdvisoryManager) Stop() {
 	am.Lock()
 	defer am.Unlock()
 	if am.listenerMap == nil {

--- a/surveyor/observation.go
+++ b/surveyor/observation.go
@@ -408,8 +408,8 @@ type ServiceObsManager struct {
 	metrics     *ServiceObsMetrics
 }
 
-// newServiceObservationManager creates a ServiceObsManager for managing Service Observations
-func newServiceObservationManager(provider ConnProvider, logger *logrus.Logger, metrics *ServiceObsMetrics) *ServiceObsManager {
+// NewServiceObservationManager creates a ServiceObsManager for managing Service Observations
+func NewServiceObservationManager(provider ConnProvider, logger *logrus.Logger, metrics *ServiceObsMetrics) *ServiceObsManager {
 	return &ServiceObsManager{
 		provider: provider,
 		logger:   logger,
@@ -417,7 +417,7 @@ func newServiceObservationManager(provider ConnProvider, logger *logrus.Logger, 
 	}
 }
 
-func (om *ServiceObsManager) start() {
+func (om *ServiceObsManager) Start() {
 	om.Lock()
 	defer om.Unlock()
 	if om.listenerMap != nil {
@@ -435,7 +435,7 @@ func (om *ServiceObsManager) IsRunning() bool {
 	return om.listenerMap != nil
 }
 
-func (om *ServiceObsManager) stop() {
+func (om *ServiceObsManager) Stop() {
 	om.Lock()
 	defer om.Unlock()
 	if om.listenerMap == nil {

--- a/surveyor/surveyor.go
+++ b/surveyor/surveyor.go
@@ -145,10 +145,10 @@ func NewSurveyor(opts *Options) (*Surveyor, error) {
 	}
 
 	serviceObsMetrics := NewServiceObservationMetrics(promRegistry, opts.ConstLabels)
-	serviceObsManager := newServiceObservationManager(opts.Provider, opts.Logger, serviceObsMetrics)
+	serviceObsManager := NewServiceObservationManager(opts.Provider, opts.Logger, serviceObsMetrics)
 	serviceFsWatcher := newServiceObservationFSWatcher(opts.Logger, serviceObsManager)
 	jsAdvisoryMetrics := NewJetStreamAdvisoryMetrics(promRegistry, opts.ConstLabels)
-	jsAdvisoryManager := newJetStreamAdvisoryManager(opts.Provider, opts.Logger, jsAdvisoryMetrics)
+	jsAdvisoryManager := NewJetStreamAdvisoryManager(opts.Provider, opts.Logger, jsAdvisoryMetrics)
 	jsFsWatcher := newJetStreamAdvisoryFSWatcher(opts.Logger, jsAdvisoryManager)
 
 	return &Surveyor{
@@ -397,7 +397,7 @@ func (s *Surveyor) startJetStreamAdvisories() {
 		return
 	}
 
-	s.jsAdvisoryManager.start()
+	s.jsAdvisoryManager.Start()
 	dir := s.opts.JetStreamConfigDir
 	if dir == "" {
 		s.logger.Debugln("skipping JetStream advisory startup, no directory configured")
@@ -431,7 +431,7 @@ func (s *Surveyor) startServiceObservations() {
 		return
 	}
 
-	s.serviceObsManager.start()
+	s.serviceObsManager.Start()
 	dir := s.opts.ObservationConfigDir
 	if dir == "" {
 		s.logger.Debugln("skipping service observation startup, no directory configured")
@@ -547,10 +547,10 @@ func (s *Surveyor) Stop() {
 	}
 
 	s.serviceObsFSWatcher.stop()
-	s.serviceObsManager.stop()
+	s.serviceObsManager.Stop()
 
 	s.jsAdvisoryFSWatcher.stop()
-	s.jsAdvisoryManager.stop()
+	s.jsAdvisoryManager.Stop()
 
 	s.connProvider.Close(true)
 	s.running = false


### PR DESCRIPTION
The `ServiceObsManager` and `JSAdvisoryManager` types are public but their factory functions are private. The `Start` and `Stop` functions are also private, rendering both structs unusable outside of the `surveyor` package.

This PR makes the factory, start, and stop functions public so these public structs can be used.