### PR TITLE
Add gomemlimit

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ ENV GO111MODULE=on
 ENV CGO_ENABLED=0
 RUN go build
 
-FROM alpine:latest as osdeps
+FROM alpine:latest AS osdeps
 RUN apk add --no-cache ca-certificates
 
 FROM alpine:3.21

--- a/README.md
+++ b/README.md
@@ -357,19 +357,21 @@ Example file format:
   "tls_ca":     "/path/to/ca.pem, defaults to surveyor's ca if one exists",
   "tls_cert":   "/path/to/cert.pem, defaults to surveyor's cert if one exists",
   "tls_key":    "/path/to/key.pem, defaults to surveyor's key if one exists"
-}.
+}
 ```
 
 Files are watched and updated using [fsnotify](https://github.com/fsnotify/fsnotify)
 
 ## Development
 
-The easiest way to test your changes is to build local image: 
+The easiest way to test your changes is to build local image:
+
 ```
 docker build -t natsio/nats-surveyor:latest --debug .
 ```
 
 You can then use the image against local cluster from docker-compse:
+
 ```
 NATS_SURVEYOR_USER=system NATS_SURVEYOR_PASSWORD=s3cret NATS_SURVEYOR_SERVERS=nats://host.docker.internal:4222 docker compose up
 ```

--- a/README.md
+++ b/README.md
@@ -357,10 +357,22 @@ Example file format:
   "tls_ca":     "/path/to/ca.pem, defaults to surveyor's ca if one exists",
   "tls_cert":   "/path/to/cert.pem, defaults to surveyor's cert if one exists",
   "tls_key":    "/path/to/key.pem, defaults to surveyor's key if one exists"
-}
+}.
 ```
 
 Files are watched and updated using [fsnotify](https://github.com/fsnotify/fsnotify)
+
+## Development
+
+The easiest way to test your changes is to build local image: 
+```
+docker build -t natsio/nats-surveyor:latest --debug .
+```
+
+You can then use the image against local cluster from docker-compse:
+```
+NATS_SURVEYOR_USER=system NATS_SURVEYOR_PASSWORD=s3cret NATS_SURVEYOR_SERVERS=nats://host.docker.internal:4222 docker compose up
+```
 
 ## TODO
 

--- a/cicd/Dockerfile
+++ b/cicd/Dockerfile
@@ -1,5 +1,5 @@
 #syntax=docker/dockerfile:1.13
-FROM goreleaser as build
+FROM goreleaser AS build
 
 ARG GO_APP
 

--- a/docker-compose/docker-compose.yml
+++ b/docker-compose/docker-compose.yml
@@ -32,7 +32,7 @@ services:
   prometheus:
     image: prom/prometheus:${PROMETHEUS_DOCKER_TAG}
     container_name: prometheus
-    restart: always
+    restart: "no"
     volumes:
       - ./prometheus/:/etc/prometheus/
       - $PROMETHEUS_STORAGE:/usr/local/share/prometheus

--- a/docker-compose/grafana/provisioning/dashboards/nats-surveyor-dashboard.json
+++ b/docker-compose/grafana/provisioning/dashboards/nats-surveyor-dashboard.json
@@ -4016,7 +4016,34 @@
               },
               "unit": "decbytes"
             },
-            "overrides": []
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byRegexp",
+                  "options": ".* \\(limit\\)"
+                },
+                "properties": [
+                  {
+                    "id": "custom.lineStyle",
+                    "value": {
+                      "dash": [
+                        10,
+                        10
+                      ],
+                      "fill": "dash"
+                    }
+                  },
+                  {
+                    "id": "custom.lineWidth",
+                    "value": 2
+                  },
+                  {
+                    "id": "custom.fillOpacity",
+                    "value": 0
+                  }
+                ]
+              }
+            ]
           },
           "gridPos": {
             "h": 7,
@@ -4043,8 +4070,13 @@
           "targets": [
             {
               "expr": "nats_core_mem_bytes{server_cluster=~\"$cluster\"}",
-              "legendFormat": "{{server_name}}",
+              "legendFormat": "{{server_name}} (usage)",
               "refId": "A"
+            },
+            {
+              "expr": "nats_core_go_memlimit_bytes{server_cluster=~\"$cluster\"}",
+              "legendFormat": "{{server_name}} (GOMEMLIMIT)",
+              "refId": "B"
             }
           ],
           "title": "Memory",

--- a/docker-compose/grafana/provisioning/dashboards/nats-surveyor-dashboard.json
+++ b/docker-compose/grafana/provisioning/dashboards/nats-surveyor-dashboard.json
@@ -4161,10 +4161,6 @@
               "expr": "nats_core_mem_bytes{server_cluster=~\"$cluster\"} / nats_core_go_memlimit_bytes{server_cluster=~\"$cluster\"} * 100",
               "legendFormat": "{{server_name}}",
               "refId": "A",
-              "datasource": {
-                "type": "prometheus",
-                "uid": "$datasource"
-              },
               "editorMode": "code",
               "range": true
             }

--- a/docker-compose/grafana/provisioning/dashboards/nats-surveyor-dashboard.json
+++ b/docker-compose/grafana/provisioning/dashboards/nats-surveyor-dashboard.json
@@ -4020,7 +4020,7 @@
               {
                 "matcher": {
                   "id": "byRegexp",
-                  "options": ".* \\(limit\\)"
+                  "options": ".*GOMEMLIMIT.*"
                 },
                 "properties": [
                   {

--- a/docker-compose/grafana/provisioning/dashboards/nats-surveyor-dashboard.json
+++ b/docker-compose/grafana/provisioning/dashboards/nats-surveyor-dashboard.json
@@ -4081,6 +4081,111 @@
           ],
           "title": "Memory",
           "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${prom_ds}"
+          },
+          "id": 85,
+          "type": "timeseries",
+          "title": "Memory Usage (% of GOMEMLIMIT)",
+          "gridPos": {
+            "x": 0,
+            "y": 17,
+            "h": 7,
+            "w": 12
+          },
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "drawStyle": "line",
+                "lineInterpolation": "linear",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "lineWidth": 2,
+                "fillOpacity": 10,
+                "gradientMode": "none",
+                "spanNulls": true,
+                "insertNulls": false,
+                "showPoints": "never",
+                "pointSize": 5,
+                "stacking": {
+                  "mode": "none",
+                  "group": "A"
+                },
+                "axisPlacement": "auto",
+                "axisLabel": "",
+                "axisColorMode": "text",
+                "axisBorderShow": false,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "axisCenteredZero": false,
+                "hideFrom": {
+                  "tooltip": false,
+                  "viz": false,
+                  "legend": false
+                },
+                "thresholdsStyle": {
+                  "mode": "line"
+                }
+              },
+              "color": {
+                "mode": "palette-classic"
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "value": 0,
+                    "color": "#EAB839"
+                  }
+                ]
+              },
+              "links": [],
+              "max": 100,
+              "min": 0,
+              "unit": "percent"
+            },
+            "overrides": []
+          },
+          "pluginVersion": "8.3.4",
+          "targets": [
+            {
+              "expr": "nats_core_mem_bytes{server_cluster=~\"$cluster\"} / nats_core_go_memlimit_bytes{server_cluster=~\"$cluster\"} * 100",
+              "legendFormat": "{{server_name}}",
+              "refId": "A",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "$datasource"
+              },
+              "editorMode": "code",
+              "range": true
+            }
+          ],
+          "options": {
+            "tooltip": {
+              "mode": "single",
+              "sort": "none",
+              "hideZeros": false
+            },
+            "legend": {
+              "showLegend": true,
+              "displayMode": "table",
+              "placement": "bottom",
+              "calcs": [
+                "lastNotNull",
+                "max",
+                "min"
+              ]
+            }
+          }
         }
       ],
       "title": "Node Resource Usage",

--- a/docker-compose/grafana/provisioning/dashboards/noderesource-dashboard.json
+++ b/docker-compose/grafana/provisioning/dashboards/noderesource-dashboard.json
@@ -215,7 +215,14 @@
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
-      "seriesOverrides": [],
+      "seriesOverrides": [
+        {
+          "alias": "/.*\\(limit\\)/",
+          "dashes": true,
+          "fill": 0,
+          "linewidth": 2
+        }
+      ],
       "spaceLength": 10,
       "stack": false,
       "steppedLine": false,
@@ -224,6 +231,11 @@
           "expr": "nats_core_mem_bytes{server_cluster=~\"$cluster\"}",
           "legendFormat": "{{server_name}}",
           "refId": "A"
+        },
+        {
+          "expr": "nats_core_go_memlimit_bytes{server_cluster=~\"$cluster\"}",
+          "legendFormat": "{{server_name}} (limit)",
+          "refId": "B"
         }
       ],
       "thresholds": [],
@@ -231,6 +243,7 @@
       "timeRegions": [],
       "timeShift": null,
       "title": "Memory",
+      "description": "nats_core_mem_bytes: Server memory gauge (current usage) | nats_core_go_memlimit_bytes: GOMEMLIMIT setting in bytes (0 if not set)",
       "tooltip": {
         "shared": true,
         "sort": 2,

--- a/docker-compose/grafana/provisioning/dashboards/noderesource-dashboard.json
+++ b/docker-compose/grafana/provisioning/dashboards/noderesource-dashboard.json
@@ -215,14 +215,7 @@
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
-      "seriesOverrides": [
-        {
-          "alias": "/.*\\(limit\\)/",
-          "dashes": true,
-          "fill": 0,
-          "linewidth": 2
-        }
-      ],
+      "seriesOverrides": [],
       "spaceLength": 10,
       "stack": false,
       "steppedLine": false,
@@ -231,11 +224,6 @@
           "expr": "nats_core_mem_bytes{server_cluster=~\"$cluster\"}",
           "legendFormat": "{{server_name}}",
           "refId": "A"
-        },
-        {
-          "expr": "nats_core_go_memlimit_bytes{server_cluster=~\"$cluster\"}",
-          "legendFormat": "{{server_name}} (limit)",
-          "refId": "B"
         }
       ],
       "thresholds": [],
@@ -243,7 +231,6 @@
       "timeRegions": [],
       "timeShift": null,
       "title": "Memory",
-      "description": "nats_core_mem_bytes: Server memory gauge (current usage) | nats_core_go_memlimit_bytes: GOMEMLIMIT setting in bytes (0 if not set)",
       "tooltip": {
         "shared": true,
         "sort": 2,

--- a/surveyor/collector_statz.go
+++ b/surveyor/collector_statz.go
@@ -353,7 +353,7 @@ func (sc *StatzCollector) buildDescs() {
 	sc.descs.Start = newGaugeVec(newName("start_time"), "Server start time gauge", sc.constLabels, sc.serverLabels)
 	sc.descs.Uptime = newGaugeVec(newName("uptime"), "Server uptime gauge", sc.constLabels, sc.serverLabels)
 	sc.descs.Mem = newGaugeVec(newName("mem_bytes"), "Server memory gauge", sc.constLabels, sc.serverLabels)
-	sc.descs.GoMemLimit = newGaugeVec(newName("go_memlimit_bytes"), "GOMEMLIMIT setting in bytes (0 if not set)", sc.constLabels, sc.serverLabels)
+	sc.descs.GoMemLimit = newGaugeVec(newName("go_memlimit_bytes"), "Server GOMEMLIMIT gauge (0 if not set)", sc.constLabels, sc.serverLabels)
 	sc.descs.Cores = newGaugeVec(newName("core_count"), "Machine cores gauge", sc.constLabels, sc.serverLabels)
 	sc.descs.CPU = newGaugeVec(newName("cpu_percentage"), "Server cpu utilization gauge", sc.constLabels, sc.serverLabels)
 	sc.descs.Connections = newGaugeVec(newName("connection_count"), "Current number of client connections gauge", sc.constLabels, sc.serverLabels)

--- a/surveyor/collector_statz.go
+++ b/surveyor/collector_statz.go
@@ -49,6 +49,7 @@ type statzDescs struct {
 	Start            *GaugeVec
 	Uptime           *GaugeVec
 	Mem              *GaugeVec
+	GoMemLimit       *GaugeVec
 	Cores            *GaugeVec
 	CPU              *GaugeVec
 	Connections      *GaugeVec
@@ -352,6 +353,7 @@ func (sc *StatzCollector) buildDescs() {
 	sc.descs.Start = newGaugeVec(newName("start_time"), "Server start time gauge", sc.constLabels, sc.serverLabels)
 	sc.descs.Uptime = newGaugeVec(newName("uptime"), "Server uptime gauge", sc.constLabels, sc.serverLabels)
 	sc.descs.Mem = newGaugeVec(newName("mem_bytes"), "Server memory gauge", sc.constLabels, sc.serverLabels)
+	sc.descs.GoMemLimit = newGaugeVec(newName("go_memlimit_bytes"), "GOMEMLIMIT setting in bytes (0 if not set)", sc.constLabels, sc.serverLabels)
 	sc.descs.Cores = newGaugeVec(newName("core_count"), "Machine cores gauge", sc.constLabels, sc.serverLabels)
 	sc.descs.CPU = newGaugeVec(newName("cpu_percentage"), "Server cpu utilization gauge", sc.constLabels, sc.serverLabels)
 	sc.descs.Connections = newGaugeVec(newName("connection_count"), "Current number of client connections gauge", sc.constLabels, sc.serverLabels)
@@ -1607,6 +1609,7 @@ func (sc *StatzCollector) Collect(ch chan<- prometheus.Metric) {
 			metrics.newGaugeMetric(sc.descs.Start, float64(sm.Stats.Start.UnixNano()), labels)
 			metrics.newGaugeMetric(sc.descs.Uptime, time.Since(sm.Stats.Start).Seconds(), labels)
 			metrics.newGaugeMetric(sc.descs.Mem, float64(sm.Stats.Mem), labels)
+			metrics.newGaugeMetric(sc.descs.GoMemLimit, float64(sm.Stats.MemLimit), labels)
 			metrics.newGaugeMetric(sc.descs.Cores, float64(sm.Stats.Cores), labels)
 			metrics.newGaugeMetric(sc.descs.CPU, sm.Stats.CPU, labels)
 			metrics.newGaugeMetric(sc.descs.Connections, float64(sm.Stats.Connections), labels)

--- a/surveyor/collector_statz_test.go
+++ b/surveyor/collector_statz_test.go
@@ -244,11 +244,11 @@ func TestStatzCollector_GoMemLimit(t *testing.T) {
 			}
 
 			output := gatherStatzCollectorMetrics(t, sc)
-			
+
 			if !strings.Contains(output, "nats_core_go_memlimit_bytes") {
 				t.Fatalf("missing GOMEMLIMIT metric in output:\n%v", output)
 			}
-			
+
 			if !strings.Contains(output, tt.expectedMetric) {
 				t.Fatalf("expected metric value not found. Expected: %s\nActual output:\n%v", tt.expectedMetric, output)
 			}


### PR DESCRIPTION
It would be nice to see right on the graph that memory usage is at GOMEMLIMIT.
Add metric, and add it to the graph.

##Test plan:
Deployed local cluster, run Surveyor through docker compose.
Not set:
```
# HELP nats_core_go_memlimit_bytes Server GOMEMLIMIT gauge (0 if not set)
# TYPE nats_core_go_memlimit_bytes gauge
nats_core_go_memlimit_bytes{server_cluster="proc_compose",server_id="NBIFJZEF5Z75YJCKKASMWIIABMU6KSWKM2OVJKH4BGMJQCS7PGPB7XVZ",server_name="s1"} 0
nats_core_go_memlimit_bytes{server_cluster="proc_compose",server_id="NBRNZV3C6NT25C7BDEUJLOYDL4FC4A7ZBZPQ3K6BKNEECJOW7YO5JOTT",server_name="s2"} 0
nats_core_go_memlimit_bytes{server_cluster="proc_compose",server_id="NCF6EYD4X6E62VMEH2EF6S6FY2LSJL52PDHORPJH4FEHXQX53KUOQ3X6",server_name="s3"} 0

```
Set:
```
# curl -s http://0.0.0.0:7777/metrics | grep memli
# HELP nats_core_go_memlimit_bytes Server GOMEMLIMIT gauge (0 if not set)
# TYPE nats_core_go_memlimit_bytes gauge
nats_core_go_memlimit_bytes{server_cluster="proc_compose",server_id="NDD7VT6BCZIGJRW5EDYQNN7W2RRBGODFV5AP77WQCBWMXCPGGRZBFCEO",server_name="s1"} 3.1138512896e+10
nats_core_go_memlimit_bytes{server_cluster="proc_compose",server_id="NDUPZ5CM2E73ESECKWN4WIGPMHWUOFW4FTBQ6UI4F7ES2CD4O5ZPSNAX",server_name="s3"} 3.1138512896e+10
nats_core_go_memlimit_bytes{server_cluster="proc_compose",server_id="NDWH5UL63F7MBYA6TULWOCFMF4REJ7FPRFQGQA2FE3V2GP3NBDH4DMWE",server_name="s2"} 3.1138512896e+10
```


Dashboard was updated:
<img width="2430" height="703" alt="image" src="https://github.com/user-attachments/assets/ba632e80-9a44-4411-8a27-353fd888c58b" />

And per @jarret's suggestion, also added graph for mem usage as % of GOMEMLIMIT


Tested against local cluster using old Graphana to make sure changes are compatible:
```
# GRAFANA_DOCKER_TAG=8.3.4 NATS_SURVEYOR_USER=system NATS_SURVEYOR_PASSWORD=s3cret NATS_SURVEYOR_SERVERS=nats://host.docker.internal:4222 docker compose up
```
