### PR TITLE
Improve JSZ logic

### DIFF
--- a/surveyor/collector_statz.go
+++ b/surveyor/collector_statz.go
@@ -1438,8 +1438,8 @@ func (sc *StatzCollector) MetricInfos() []MetricInfo {
 	}
 
 	// Account scope metrics
-	_, collectJsz := shouldCollectJsz(sc.collectJsz)
-	if sc.collectAccounts || collectJsz {
+	collectJsz, shouldCollectJsz := shouldCollectJsz(sc.collectJsz)
+	if sc.collectAccounts || shouldCollectJsz {
 		metrics = append(metrics,
 			sc.descs.accCount,
 			sc.descs.accConnCount,
@@ -1500,26 +1500,32 @@ func (sc *StatzCollector) MetricInfos() []MetricInfo {
 			sc.descs.accJetstreamReplicaCount,
 		)
 
-		if collectJsz {
-			metrics = append(metrics,
-				// JSZ Stream metrics.
-				sc.descs.accJszStreamMsgs,
-				sc.descs.accJszStreamBytes,
-				sc.descs.accJszStreamFirstSeq,
-				sc.descs.accJszStreamLastSeq,
-				sc.descs.accJszStreamConsumerCount,
-				sc.descs.accJszStreamSubjectCount,
+		if shouldCollectJsz {
+			// JSZ Stream metrics.
+			if collectJsz == CollectJszAll || collectJsz == CollectJszStreams {
+				metrics = append(metrics,
+					sc.descs.accJszStreamMsgs,
+					sc.descs.accJszStreamBytes,
+					sc.descs.accJszStreamFirstSeq,
+					sc.descs.accJszStreamLastSeq,
+					sc.descs.accJszStreamConsumerCount,
+					sc.descs.accJszStreamSubjectCount,
+				)
+			}
 
-				// JSZ Consumer metrics.
-				sc.descs.accJszConsumerDeliveredConsumerSeq,
-				sc.descs.accJszConsumerDeliveredStreamSeq,
-				sc.descs.accJszConsumerNumAckPending,
-				sc.descs.accJszConsumerNumRedelivered,
-				sc.descs.accJszConsumerNumWaiting,
-				sc.descs.accJszConsumerNumPending,
-				sc.descs.accJszConsumerAckFloorStreamSeq,
-				sc.descs.accJszConsumerAckFloorConsumerSeq,
-			)
+			// JSZ Consumer metrics.
+			if collectJsz == CollectJszAll || collectJsz == CollectJszConsumers {
+				metrics = append(metrics,
+					sc.descs.accJszConsumerDeliveredConsumerSeq,
+					sc.descs.accJszConsumerDeliveredStreamSeq,
+					sc.descs.accJszConsumerNumAckPending,
+					sc.descs.accJszConsumerNumRedelivered,
+					sc.descs.accJszConsumerNumWaiting,
+					sc.descs.accJszConsumerNumPending,
+					sc.descs.accJszConsumerAckFloorStreamSeq,
+					sc.descs.accJszConsumerAckFloorConsumerSeq,
+				)
+			}
 		}
 	}
 
@@ -1768,58 +1774,82 @@ func (sc *StatzCollector) Collect(ch chan<- prometheus.Metric) {
 					metrics.newGaugeMetric(sc.descs.accJetstreamConsumerCount, streamStat.consumerCount, append(accLabels, streamStat.streamName, streamStat.raftGroup))
 					metrics.newGaugeMetric(sc.descs.accJetstreamReplicaCount, streamStat.replicaCount, append(accLabels, streamStat.streamName, streamStat.raftGroup))
 				}
-				for _, streamStat := range stat.jszData {
-					showStreamMetrics := !sc.jszLeadersOnly || sc.jszLeadersOnly && streamStat.serverName == streamStat.streamLeader
 
-					if showStreamMetrics {
-						metrics.newGaugeMetric(sc.descs.accJszStreamMsgs,
-							streamStat.streamMessages,
-							append(accLabels,
-								streamStat.clusterName, streamStat.raftGroup, streamStat.serverID, streamStat.serverName,
-								streamStat.streamName, streamStat.streamLeader,
-							),
-						)
-						metrics.newGaugeMetric(sc.descs.accJszStreamBytes,
-							streamStat.streamBytes,
-							append(accLabels,
-								streamStat.clusterName, streamStat.raftGroup, streamStat.serverID, streamStat.serverName,
-								streamStat.streamName, streamStat.streamLeader,
-							),
-						)
-						metrics.newGaugeMetric(sc.descs.accJszStreamFirstSeq,
-							streamStat.streamFirstSeq,
-							append(accLabels,
-								streamStat.clusterName, streamStat.raftGroup, streamStat.serverID, streamStat.serverName,
-								streamStat.streamName, streamStat.streamLeader,
-							),
-						)
-						metrics.newGaugeMetric(sc.descs.accJszStreamLastSeq,
-							streamStat.streamLastSeq,
-							append(accLabels,
-								streamStat.clusterName, streamStat.raftGroup, streamStat.serverID, streamStat.serverName,
-								streamStat.streamName, streamStat.streamLeader,
-							),
-						)
-						metrics.newGaugeMetric(sc.descs.accJszStreamConsumerCount,
-							streamStat.streamConsumerCount,
-							append(accLabels,
-								streamStat.clusterName, streamStat.raftGroup, streamStat.serverID, streamStat.serverName,
-								streamStat.streamName, streamStat.streamLeader,
-							),
-						)
-						metrics.newGaugeMetric(sc.descs.accJszStreamSubjectCount,
-							streamStat.streamSubjectCount,
-							append(accLabels,
-								streamStat.clusterName, streamStat.raftGroup, streamStat.serverID, streamStat.serverName,
-								streamStat.streamName, streamStat.streamLeader,
-							),
-						)
+				collectJsz, shouldCollectJsz := shouldCollectJsz(sc.collectJsz)
+				if !shouldCollectJsz {
+					continue
+				}
+				for _, streamStat := range stat.jszData {
+					hasFilters := len(sc.jszFilterSet) > 0
+
+					showStreamMetrics := !sc.jszLeadersOnly || sc.jszLeadersOnly && streamStat.serverName == streamStat.streamLeader
+					showJszStreams := collectJsz == CollectJszAll || collectJsz == CollectJszStreams
+					if showStreamMetrics && showJszStreams {
+						if sc.jszFilterSet[StreamTotalMessages] || !hasFilters {
+							metrics.newGaugeMetric(sc.descs.accJszStreamMsgs,
+								streamStat.streamMessages,
+								append(accLabels,
+									streamStat.clusterName, streamStat.raftGroup, streamStat.serverID, streamStat.serverName,
+									streamStat.streamName, streamStat.streamLeader,
+								),
+							)
+						}
+
+						if sc.jszFilterSet[StreamTotalBytes] || !hasFilters {
+							metrics.newGaugeMetric(sc.descs.accJszStreamBytes,
+								streamStat.streamBytes,
+								append(accLabels,
+									streamStat.clusterName, streamStat.raftGroup, streamStat.serverID, streamStat.serverName,
+									streamStat.streamName, streamStat.streamLeader,
+								),
+							)
+						}
+
+						if sc.jszFilterSet[StreamFirstSeq] || !hasFilters {
+							metrics.newGaugeMetric(sc.descs.accJszStreamFirstSeq,
+								streamStat.streamFirstSeq,
+								append(accLabels,
+									streamStat.clusterName, streamStat.raftGroup, streamStat.serverID, streamStat.serverName,
+									streamStat.streamName, streamStat.streamLeader,
+								),
+							)
+						}
+
+						if sc.jszFilterSet[StreamLastSeq] || !hasFilters {
+							metrics.newGaugeMetric(sc.descs.accJszStreamLastSeq,
+								streamStat.streamLastSeq,
+								append(accLabels,
+									streamStat.clusterName, streamStat.raftGroup, streamStat.serverID, streamStat.serverName,
+									streamStat.streamName, streamStat.streamLeader,
+								),
+							)
+						}
+
+						if sc.jszFilterSet[StreamConsumerCount] || !hasFilters {
+							metrics.newGaugeMetric(sc.descs.accJszStreamConsumerCount,
+								streamStat.streamConsumerCount,
+								append(accLabels,
+									streamStat.clusterName, streamStat.raftGroup, streamStat.serverID, streamStat.serverName,
+									streamStat.streamName, streamStat.streamLeader,
+								),
+							)
+						}
+
+						if sc.jszFilterSet[StreamSubjectCount] || !hasFilters {
+							metrics.newGaugeMetric(sc.descs.accJszStreamSubjectCount,
+								streamStat.streamSubjectCount,
+								append(accLabels,
+									streamStat.clusterName, streamStat.raftGroup, streamStat.serverID, streamStat.serverName,
+									streamStat.streamName, streamStat.streamLeader,
+								),
+							)
+						}
 					}
 
-					hasFilters := len(sc.jszFilterSet) > 0
 					for _, consumerStat := range streamStat.consumerStats {
 						showConsumerMetrics := !sc.jszLeadersOnly || sc.jszLeadersOnly && streamStat.serverName == consumerStat.consumerLeader
-						if showConsumerMetrics {
+						showJszConsumers := collectJsz == CollectJszAll || collectJsz == CollectJszConsumers
+						if showConsumerMetrics && showJszConsumers {
 							raftGroup := consumerStat.consumerRaftGroup
 
 							if sc.jszFilterSet[ConsumerDeliveredConsumerSeq] || !hasFilters {

--- a/surveyor/collector_statz.go
+++ b/surveyor/collector_statz.go
@@ -38,6 +38,7 @@ const accStatZeroConnSkip = 3
 type CollectJsz string
 
 const (
+	CollectJszNone      CollectJsz = ""
 	CollectJszAll       CollectJsz = "all"
 	CollectJszStreams   CollectJsz = "streams"
 	CollectJszConsumers CollectJsz = "consumers"

--- a/surveyor/collector_statz.go
+++ b/surveyor/collector_statz.go
@@ -729,18 +729,6 @@ type WithStatsBatch struct {
 // If a NATS connection is provided, the collector will still poll for the stats and override the provided stats.
 func WithStats(batch WithStatsBatch) StatzCollectorOpt {
 	return func(sc *StatzCollector) error {
-		// Automatically set the collect flags for batch fields
-		if batch.AccStatzs != nil {
-			sc.collectAccounts = true
-			sc.collectAccountsDetailed = true
-		}
-		if batch.JsStatzs != nil {
-			sc.collectJsz = CollectJsz("all")
-		}
-		if batch.GatewayStatzs != nil {
-			sc.collectGatewayz = true
-		}
-
 		// statz
 		sc.stats = batch.Stats
 

--- a/surveyor/collector_statz_test.go
+++ b/surveyor/collector_statz_test.go
@@ -209,8 +209,8 @@ func TestStatzCollector_WithStats_Jsz(t *testing.T) {
 	tests := []test{
 		// jsz type tests
 		{
-			name:           "collect nothing",
-			jsz:            CollectJsz(""),
+			name:           "collect none",
+			jsz:            CollectJszNone,
 			jszLeadersOnly: false,
 			jszFilters:     nil,
 			assert: func(t *testing.T, test *test, output string) {

--- a/surveyor/collector_statz_test.go
+++ b/surveyor/collector_statz_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"os"
+	"slices"
 	"strings"
 	"testing"
 
@@ -79,9 +80,8 @@ func TestStatzCollector_WithStats_Account(t *testing.T) {
 	}
 
 	sc, err := NewStatzCollectorOpts(
-		WithStats(WithStatsBatch{
-			AccStatzs: []*ServerAPIAccstatzResponse{stats},
-		}),
+		WithStats(WithStatsBatch{AccStatzs: []*ServerAPIAccstatzResponse{stats}}),
+		WithCollectAccounts(true, true),
 	)
 	if err != nil {
 		t.Fatalf("error creating statz collector: %v", err)
@@ -123,9 +123,8 @@ func TestStatzCollector_WithStats_Gatewayz(t *testing.T) {
 	}
 
 	sc, err := NewStatzCollectorOpts(
-		WithStats(WithStatsBatch{
-			GatewayStatzs: []*server.ServerAPIGatewayzResponse{stats},
-		}),
+		WithStats(WithStatsBatch{GatewayStatzs: []*server.ServerAPIGatewayzResponse{stats}}),
+		WithCollectGatewayz(true),
 	)
 	if err != nil {
 		t.Fatalf("error creating statz collector: %v", err)
@@ -176,30 +175,187 @@ func TestStatzCollector_WithStats_Jsz(t *testing.T) {
 		t.Fatalf("error unmarshalling stats: %v", err)
 	}
 
-	sc, err := NewStatzCollectorOpts(
-		WithStats(WithStatsBatch{
-			JsStatzs: []*server.ServerAPIJszResponse{stats},
-		}),
-	)
-	if err != nil {
-		t.Fatalf("error creating statz collector: %v", err)
+	streamMetrics := []string{
+		"nats_stream_consumer_count",
+		"nats_stream_first_seq",
+		"nats_stream_last_seq",
+		"nats_stream_subject_count",
+		"nats_stream_total_bytes",
+		"nats_stream_total_messages",
+	}
+	consumerMetrics := []string{
+		"nats_consumer_ack_floor_consumer_seq",
+		"nats_consumer_ack_floor_stream_seq",
+		"nats_consumer_delivered_consumer_seq",
+		"nats_consumer_delivered_stream_seq",
+		"nats_consumer_num_ack_pending",
+		"nats_consumer_num_pending",
+		"nats_consumer_num_redelivered",
+		"nats_consumer_num_waiting",
 	}
 
-	output := gatherStatzCollectorMetrics(t, sc)
+	allMetrics := []string{}
+	allMetrics = append(allMetrics, streamMetrics...)
+	allMetrics = append(allMetrics, consumerMetrics...)
 
-	want := []string{
-		"nats_core_jetstream_server_jetstream_disabled",
-		"nats_core_jetstream_server_total_streams",
-		"nats_core_jetstream_server_total_consumers",
-		"nats_core_jetstream_server_total_messages",
-		"nats_core_jetstream_server_total_message_bytes",
-		"nats_core_jetstream_server_max_memory",
-		"nats_core_jetstream_server_max_storage",
+	type test struct {
+		name           string
+		jsz            CollectJsz
+		jszLeadersOnly bool
+		jszFilters     []JszFilter
+		assert         func(t *testing.T, test *test, output string)
 	}
-	for _, m := range want {
-		if !strings.Contains(output, m) {
-			t.Fatalf("invalid output, missing '%s':\n%v\n", m, output)
-		}
+
+	tests := []test{
+		// jsz type tests
+		{
+			name:           "collect nothing",
+			jsz:            CollectJsz(""),
+			jszLeadersOnly: false,
+			jszFilters:     nil,
+			assert: func(t *testing.T, test *test, output string) {
+				for _, m := range allMetrics {
+					if strings.Contains(output, m) {
+						t.Fatalf("invalid output, should not contain '%s':\n%v\n", m, output)
+					}
+				}
+			},
+		},
+		{
+			name:           "collect all",
+			jsz:            CollectJszAll,
+			jszLeadersOnly: false,
+			jszFilters:     nil,
+			assert: func(t *testing.T, test *test, output string) {
+				for _, m := range allMetrics {
+					if !strings.Contains(output, m) {
+						t.Fatalf("invalid output, missing '%s':\n%v\n", m, output)
+					}
+				}
+			},
+		},
+		{
+			name:           "collect streams",
+			jsz:            CollectJszStreams,
+			jszLeadersOnly: false,
+			jszFilters:     nil,
+			assert: func(t *testing.T, test *test, output string) {
+				for _, m := range streamMetrics {
+					if !strings.Contains(output, m) {
+						t.Fatalf("invalid output, missing '%s':\n%v\n", m, output)
+					}
+				}
+				for _, m := range consumerMetrics {
+					if strings.Contains(output, m) {
+						t.Fatalf("invalid output, should not contain '%s':\n%v\n", m, output)
+					}
+				}
+			},
+		},
+		{
+			name:           "collect consumers",
+			jsz:            CollectJszConsumers,
+			jszLeadersOnly: false,
+			jszFilters:     nil,
+			assert: func(t *testing.T, test *test, output string) {
+				for _, m := range consumerMetrics {
+					if !strings.Contains(output, m) {
+						t.Fatalf("invalid output, missing '%s':\n%v\n", m, output)
+					}
+				}
+				for _, m := range streamMetrics {
+					if strings.Contains(output, m) {
+						t.Fatalf("invalid output, should not contain '%s':\n%v\n", m, output)
+					}
+				}
+			},
+		},
+		// leaders only tests
+		{
+			name:           "collect leaders only",
+			jsz:            CollectJszAll,
+			jszLeadersOnly: true,
+			jszFilters:     nil,
+			assert: func(t *testing.T, test *test, output string) {
+				lines := strings.Split(output, "\n")
+
+				for _, m := range consumerMetrics {
+					count := 0
+					for _, line := range lines {
+						if strings.Contains(line, m) && !strings.HasPrefix(line, "#") {
+							count++
+						}
+					}
+					if count != 1 {
+						t.Fatalf("invalid output, expected %v, got %v: %v\n", 1, count, output)
+					}
+				}
+			},
+		},
+		{
+			name:           "not collect leaders only",
+			jsz:            CollectJszAll,
+			jszLeadersOnly: false,
+			jszFilters:     nil,
+			assert: func(t *testing.T, test *test, output string) {
+				lines := strings.Split(output, "\n")
+
+				for _, m := range consumerMetrics {
+					count := 0
+					for _, line := range lines {
+						if strings.Contains(line, m) && !strings.HasPrefix(line, "#") {
+							count++
+						}
+					}
+					if count != 3 {
+						t.Fatalf("invalid output, expected %v, got %v: %v\n", 3, count, output)
+					}
+				}
+			},
+		},
+		// jsz filter tests
+		{
+			name:           "collect streams with filter",
+			jsz:            CollectJszStreams,
+			jszLeadersOnly: false,
+			jszFilters:     []JszFilter{StreamTotalMessages},
+			assert: func(t *testing.T, test *test, output string) {
+				metrics := []string{}
+				for _, filter := range test.jszFilters {
+					id := JszFilterIds[filter][0]
+					m := "nats_" + id
+					metrics = append(metrics, m)
+				}
+
+				for _, m := range metrics {
+					if !strings.Contains(output, m) {
+						t.Fatalf("invalid output, missing '%s':\n%v\n", m, output)
+					}
+				}
+
+				for _, m := range allMetrics {
+					if !slices.Contains(metrics, m) && strings.Contains(output, m) {
+						t.Fatalf("invalid output, should not contain '%s':\n%v\n", m, output)
+					}
+				}
+
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			sc, err := NewStatzCollectorOpts(
+				WithStats(WithStatsBatch{JsStatzs: []*server.ServerAPIJszResponse{stats}}),
+				WithCollectJsz(test.jsz, test.jszLeadersOnly, test.jszFilters),
+			)
+			if err != nil {
+				t.Fatalf("error creating statz collector: %v", err)
+			}
+
+			output := gatherStatzCollectorMetrics(t, sc)
+			test.assert(t, &test, output)
+		})
 	}
 }
 

--- a/surveyor/testdata/stats/jsz.json
+++ b/surveyor/testdata/stats/jsz.json
@@ -75,6 +75,173 @@
                 "name": "consumer1",
                 "raft_group": "raft"
               }
+            ],
+            "consumer_detail": [
+              {
+                "stream_name": "stream1",
+                "name": "consumer1",
+                "created": "2025-01-01T00:00:00Z",
+                "cluster": {
+                  "name": "cluster1",
+                  "raft_group": "raft",
+                  "leader": "server1",
+                  "leader_since": "2025-01-01T00:00:00Z"
+                },
+                "config": {
+                  "durable_name": "consumer1",
+                  "name": "consumer1",
+                  "description": "super cool consumer",
+                  "deliver_policy": "all",
+                  "ack_policy": "explicit",
+                  "ack_wait": 1000,
+                  "max_deliver": -1,
+                  "backoff": [
+                    1000,
+                    2000,
+                    3000
+                  ],
+                  "filter_subject": "foo",
+                  "filter_subjects": [
+                    "foo"
+                  ],
+                  "replay_policy": "instant",
+                  "sample_freq": "1s",
+                  "max_waiting": -1,
+                  "max_ack_pending": -1,
+                  "flow_control": true,
+                  "headers_only": false,
+                  "max_batch": -1,
+                  "max_expires": 1000,
+                  "max_bytes": 1000,
+                  "replicas": 3,
+                  "metadata": {
+                    "foo": "bar"
+                  }
+                },
+                "delivered": {
+                  "consumer_seq": 100,
+                  "stream_seq": 100
+                },
+                "ack_floor": {
+                  "consumer_seq": 100,
+                  "stream_seq": 100
+                },
+                "num_ack_pending": 100,
+                "num_redelivered": 100,
+                "num_waiting": 100,
+                "num_pending": 100,
+                "timestamp": "2025-01-01T00:00:00Z"
+              },
+              {
+                "stream_name": "stream1",
+                "name": "consumer2",
+                "created": "2025-01-01T00:00:00Z",
+                "cluster": {
+                  "name": "cluster1",
+                  "raft_group": "raft",
+                  "leader": "server2",
+                  "leader_since": "2025-01-01T00:00:00Z"
+                },
+                "config": {
+                  "durable_name": "consumer2",
+                  "name": "consumer2",
+                  "description": "super cool consumer",
+                  "deliver_policy": "all",
+                  "ack_policy": "explicit",
+                  "ack_wait": 1000,
+                  "max_deliver": -1,
+                  "backoff": [
+                    1000,
+                    2000,
+                    3000
+                  ],
+                  "filter_subject": "foo",
+                  "filter_subjects": [
+                    "foo"
+                  ],
+                  "replay_policy": "instant",
+                  "sample_freq": "1s",
+                  "max_waiting": -1,
+                  "max_ack_pending": -1,
+                  "flow_control": true,
+                  "headers_only": false,
+                  "max_batch": -1,
+                  "max_expires": 1000,
+                  "max_bytes": 1000,
+                  "replicas": 3,
+                  "metadata": {
+                    "foo": "bar"
+                  }
+                },
+                "delivered": {
+                  "consumer_seq": 100,
+                  "stream_seq": 100
+                },
+                "ack_floor": {
+                  "consumer_seq": 100,
+                  "stream_seq": 100
+                },
+                "num_ack_pending": 100,
+                "num_redelivered": 100,
+                "num_waiting": 100,
+                "num_pending": 100,
+                "timestamp": "2025-01-01T00:00:00Z"
+              },
+              {
+                "stream_name": "stream1",
+                "name": "consumer3",
+                "created": "2025-01-01T00:00:00Z",
+                "cluster": {
+                  "name": "cluster1",
+                  "raft_group": "raft",
+                  "leader": "server3",
+                  "leader_since": "2025-01-01T00:00:00Z"
+                },
+                "config": {
+                  "durable_name": "consumer3",
+                  "name": "consumer3",
+                  "description": "super cool consumer",
+                  "deliver_policy": "all",
+                  "ack_policy": "explicit",
+                  "ack_wait": 1000,
+                  "max_deliver": -1,
+                  "backoff": [
+                    1000,
+                    2000,
+                    3000
+                  ],
+                  "filter_subject": "foo",
+                  "filter_subjects": [
+                    "foo"
+                  ],
+                  "replay_policy": "instant",
+                  "sample_freq": "1s",
+                  "max_waiting": -1,
+                  "max_ack_pending": -1,
+                  "flow_control": true,
+                  "headers_only": false,
+                  "max_batch": -1,
+                  "max_expires": 1000,
+                  "max_bytes": 1000,
+                  "replicas": 3,
+                  "metadata": {
+                    "foo": "bar"
+                  }
+                },
+                "delivered": {
+                  "consumer_seq": 100,
+                  "stream_seq": 100
+                },
+                "ack_floor": {
+                  "consumer_seq": 100,
+                  "stream_seq": 100
+                },
+                "num_ack_pending": 100,
+                "num_redelivered": 100,
+                "num_waiting": 100,
+                "num_pending": 100,
+                "timestamp": "2025-01-01T00:00:00Z"
+              }
             ]
           }
         ]


### PR DESCRIPTION
- Fix JSZ metrics ignoring `collectJsz` option
- Fix JSZ filters not used for stream metrics 
- Add JSZ-specific tests
- Add `CollectJszNone`
- [Don't automatically configure `StatzCollector` options when using `WithStats` option](https://github.com/nats-io/nats-surveyor/commit/97462de6800a4aa4e75396525d3c11cfd7ef0ff3)