### PR TITLE
Improve timing of observation tests

### DIFF
--- a/surveyor/surveyor_test.go
+++ b/surveyor/surveyor_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/nats-io/nats.go"
 	"github.com/prometheus/common/expfmt"
 	"github.com/prometheus/common/model"
+	"github.com/sirupsen/logrus"
 )
 
 // Testing constants
@@ -81,6 +82,7 @@ func httpGet(url string) (*http.Response, error) {
 func getTestOptions() *Options {
 	o := GetDefaultOptions()
 	o.Credentials = st.SystemCreds
+	o.Logger.SetLevel(logrus.ErrorLevel) // reduce logging noise
 	return o
 }
 


### PR DESCRIPTION
Improves upon use of `time.Sleep` in some tests. Instead, uses a ticker and a timer to retry assertions that may take an unknown amount of time. Based on `require.Eventually` but modified to better handle multiple assertions in the same check.

Example of a flaky test failing in CI: https://github.com/nats-io/nats-surveyor/actions/runs/17871152429/job/50959670561