### PR TITLE
Add opt-in JetStream config and Raft polling listener

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,10 @@ Flags:
       --jsz-limit int                       Limit the number of returned account jsz metrics (NATS_SURVEYOR_JSZ_LIMIT) (default 1024)
       --jsz-leaders-only                    Fetch jsz metrics from stream and consumer leaders only (NATS_SURVEYOR_JSZ_LEADERS_ONLY)
       --jsz-filter jsz-filter               Fetch selected jsz metrics only(comma separated list). Metrics: stream_total_messages,stream_total_bytes,stream_first_seq,stream_last_seq,stream_consumer_count,stream_subject_count,consumer_delivered_consumer_seq,consumer_delivered_stream_seq,consumer_ack_floor_consumer_seq,consumer_ack_floor_stream_seq,consumer_num_ack_pending,consumer_num_pending,consumer_num_redelivered,consumer_num_waiting (NATS_SURVEYOR_JSZ_FILTER) (default [])
+      --js-config-poll-interval duration    Poll JetStream stream and consumer configuration, limits and Raft peer state at this interval, 0 disables it.
+                                            Unlike the jsz options this uses the JetStream API and so needs credentials for a JetStream account rather than
+                                            the system account. Every poll lists all streams and the consumers of each of them through the meta leader, so
+                                            keep the interval generous on large clusters, 60s is a reasonable starting point (NATS_SURVEYOR_JS_CONFIG_POLL_INTERVAL)
       --sys-req-prefix string               Subject prefix for system requests ($SYS.REQ) (NATS_SURVEYOR_SYS_REQ_PREFIX) (default "$SYS.REQ")
       --log-level string                    Log level, one of: trace|debug|info|warn|error|fatal|panic (NATS_SURVEYOR_LOG_LEVEL) (default "info")
       --config string                       config file (default is ./nats-surveyor.yaml)
@@ -170,6 +174,35 @@ and picking up `num_pending`, `num_ack_pending` and `num_waiting` from the consu
                 --jsz-leaders-only \
                 --jsz-filter=consumer_num_pending,consumer_num_ack_pending,consumer_num_waiting
 ```
+
+## JetStream Configuration Metrics
+
+`--js-config-poll-interval` enables a second, opt-in JetStream collector. Where the jsz metrics describe what the streams
+and consumers are *doing*, this one describes how they are *configured* and how healthy their Raft groups are, which the
+jsz endpoint does not cover:
+
+- `nats_jetstream_stream_configuration` and `nats_jetstream_consumer_configuration`, always `1`, with the configuration
+  in the labels.
+- `nats_jetstream_stream_limit_*` and `nats_jetstream_consumer_limit_max_ack_pending`, so that saturation can be alerted
+  on, for example `nats_stream_total_messages / nats_jetstream_stream_limit_max_msgs > 0.9`.
+- `nats_jetstream_stream_peer_*` and `nats_jetstream_consumer_peer_*` plus `nats_jetstream_{stream,consumer}_replication_lag`,
+  which report per peer whether it leads the group, is current, is offline and how many operations it is behind.
+
+Two things to keep in mind before enabling it:
+
+- **It needs JetStream credentials.** This collector calls the JetStream API rather than the `$SYS` monitoring endpoints,
+  and the system account the surveyor normally connects with cannot use that API. It reuses the main `--creds` / `--user`
+  / `--password` options, so those have to belong to the JetStream account being observed. Surveyor refuses to start if
+  the credentials cannot reach the JetStream API.
+- **It costs meta leader work.** Every poll issues one `$JS.API.STREAM.LIST` page per 256 streams plus one
+  `$JS.API.CONSUMER.LIST` per stream that has consumers, and in a clustered deployment the meta leader serves all of them
+  by asking every stream and consumer leader in turn. This is unlike the jsz collector, which polls each server directly.
+  Streams without consumers are skipped, but on a large multi-tenant cluster the interval should still be measured in
+  tens of seconds rather than seconds.
+
+Cardinality scales with streams x consumers x replicas. Sequence numbers and lag are only ever gauge values, never label
+values, so the number of series is bounded by the assets themselves and series of deleted assets are removed on the
+following poll.
 
 ## Docker Compose
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -286,9 +286,13 @@ func init() {
 	)
 	_ = viper.BindPFlag("jsz-filter", rootCmd.Flags().Lookup("jsz-filter"))
 
-	// jsz-config-poll-interval
-	rootCmd.Flags().Duration("jsz-config-poll-interval", 0, "Poll JetStream stream/consumer configuration, state, and Raft info at this interval (0 disables)")
-	_ = viper.BindPFlag("jsz-config-poll-interval", rootCmd.Flags().Lookup("jsz-config-poll-interval"))
+	// js-config-poll-interval
+	rootCmd.Flags().Duration("js-config-poll-interval", 0,
+		"Poll JetStream stream and consumer configuration, limits and Raft peer state at this interval, 0 disables it.\n"+
+			"Unlike the jsz options this uses the JetStream API and so needs credentials for a JetStream account rather than\n"+
+			"the system account. Every poll lists all streams and the consumers of each of them through the meta leader, so\n"+
+			"keep the interval generous on large clusters, 60s is a reasonable starting point")
+	_ = viper.BindPFlag("js-config-poll-interval", rootCmd.Flags().Lookup("js-config-poll-interval"))
 
 	// sys-req-prefix
 	rootCmd.Flags().String("sys-req-prefix", surveyor.DefaultSysReqPrefix, "Subject prefix for system requests ($SYS.REQ)")
@@ -345,7 +349,7 @@ func getSurveyorOpts() *surveyor.Options {
 	opts.JszLimit = viper.GetInt("jsz-limit")
 	opts.JszLeadersOnly = viper.GetBool("jsz-leaders-only")
 	opts.JszFilters = jszFilters
-	opts.JSConfigPollInterval = viper.GetDuration("jsz-config-poll-interval")
+	opts.JSConfigPollInterval = viper.GetDuration("js-config-poll-interval")
 
 	opts.EnablePprof = viper.GetBool("pprof")
 	opts.SysReqPrefix = viper.GetString("sys-req-prefix")

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -286,6 +286,10 @@ func init() {
 	)
 	_ = viper.BindPFlag("jsz-filter", rootCmd.Flags().Lookup("jsz-filter"))
 
+	// jsz-config-poll-interval
+	rootCmd.Flags().Duration("jsz-config-poll-interval", 0, "Poll JetStream stream/consumer configuration, state, and Raft info at this interval (0 disables)")
+	_ = viper.BindPFlag("jsz-config-poll-interval", rootCmd.Flags().Lookup("jsz-config-poll-interval"))
+
 	// sys-req-prefix
 	rootCmd.Flags().String("sys-req-prefix", surveyor.DefaultSysReqPrefix, "Subject prefix for system requests ($SYS.REQ)")
 	_ = viper.BindPFlag("sys-req-prefix", rootCmd.Flags().Lookup("sys-req-prefix"))
@@ -341,6 +345,7 @@ func getSurveyorOpts() *surveyor.Options {
 	opts.JszLimit = viper.GetInt("jsz-limit")
 	opts.JszLeadersOnly = viper.GetBool("jsz-leaders-only")
 	opts.JszFilters = jszFilters
+	opts.JSConfigPollInterval = viper.GetDuration("jsz-config-poll-interval")
 
 	opts.EnablePprof = viper.GetBool("pprof")
 	opts.SysReqPrefix = viper.GetString("sys-req-prefix")

--- a/surveyor/jetstream_configs.go
+++ b/surveyor/jetstream_configs.go
@@ -53,19 +53,19 @@ type JSStreamConfigMetrics struct {
 	jsStreamStateDeletedNum  *prometheus.GaugeVec
 	jsStreamStateSubjectNum  *prometheus.GaugeVec
 
-	jsConsumerConfig                 *prometheus.GaugeVec
-	jsConsumerState                  *prometheus.GaugeVec
-	jsConsumerRaftInfo               *prometheus.GaugeVec
-	jsConsumerRaftPeerInfo           *prometheus.GaugeVec
-	jsConsumerReplicationLag         *prometheus.GaugeVec
-	jsConsumerAckPendingNum          *prometheus.GaugeVec
-	jsConsumerPendingNum             *prometheus.GaugeVec
-	jsConsumerRedeliveredNum         *prometheus.GaugeVec
-	jsConsumerWaitingNum             *prometheus.GaugeVec
-	jsConsumerLastAckFloorConsumer   *prometheus.GaugeVec
-	jsConsumerLastAckFloorStream     *prometheus.GaugeVec
-	jsConsumerLastDeliveredConsumer  *prometheus.GaugeVec
-	jsConsumerLastDeliveredStream    *prometheus.GaugeVec
+	jsConsumerConfig                *prometheus.GaugeVec
+	jsConsumerState                 *prometheus.GaugeVec
+	jsConsumerRaftInfo              *prometheus.GaugeVec
+	jsConsumerRaftPeerInfo          *prometheus.GaugeVec
+	jsConsumerReplicationLag        *prometheus.GaugeVec
+	jsConsumerAckPendingNum         *prometheus.GaugeVec
+	jsConsumerPendingNum            *prometheus.GaugeVec
+	jsConsumerRedeliveredNum        *prometheus.GaugeVec
+	jsConsumerWaitingNum            *prometheus.GaugeVec
+	jsConsumerLastAckFloorConsumer  *prometheus.GaugeVec
+	jsConsumerLastAckFloorStream    *prometheus.GaugeVec
+	jsConsumerLastDeliveredConsumer *prometheus.GaugeVec
+	jsConsumerLastDeliveredStream   *prometheus.GaugeVec
 
 	jsStreamLimitMaxMsgs      *prometheus.GaugeVec
 	jsStreamLimitMaxMsgsPer   *prometheus.GaugeVec

--- a/surveyor/jetstream_configs.go
+++ b/surveyor/jetstream_configs.go
@@ -20,289 +20,321 @@ import (
 	"sync"
 	"time"
 
-	"github.com/nats-io/nats.go"
-
+	"github.com/nats-io/nats.go/jetstream"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/sirupsen/logrus"
 )
 
-var (
-	streamConfigLabels           = []string{"discard_policy", "storage_type", "replica_number", "stream_name"}
-	consumerConfigLabels         = []string{"stream_name", "max_pending_ack", "ack_policy", "is_pull", "consumer_name"}
-	streamRaftInfoLabels         = []string{"stream_name", "leader", "replica_count"}
-	streamRaftPeerInfoLabels     = []string{"stream_name", "peer_name", "offline", "current", "leader"}
-	consumerRaftInfoLabels       = []string{"consumer_name", "leader", "replica_count", "stream_name"}
-	consumerStateLabels          = []string{"consumer_name", "stream_name"}
-	consumerRaftPeerInfoLabels   = []string{"stream_name", "consumer_name", "peer_name", "offline", "current", "leader"}
-	streamReplicationLagLabels   = []string{"stream_name", "peer_name"}
-	consumerReplicationLagLabels = []string{"stream_name", "consumer_name", "peer_name"}
-	streamLabel                  = []string{"stream_name"}
-	consumerStreamLabel          = []string{"consumer_name", "stream_name"}
+const (
+	// MinJSConfigPollInterval is the smallest accepted JetStream configuration
+	// polling interval. Every poll lists all streams and the consumers of each
+	// of them, and in a clustered deployment those requests are all served by
+	// the meta leader, so polling too often adds load to the very cluster that
+	// is being observed.
+	MinJSConfigPollInterval = time.Second
+
+	// jsConfigProbeTimeout bounds the JetStream API probe performed when the
+	// listener starts.
+	jsConfigProbeTimeout = 5 * time.Second
 )
 
-// DefaultJSConfigPollInterval is the polling interval used when the listener is
-// enabled without an explicit interval.
-const DefaultJSConfigPollInterval = 10 * time.Second
+var (
+	jsStreamLabels         = []string{"stream"}
+	jsStreamConfigLabels   = []string{"stream", "discard_policy", "storage_type", "replica_number"}
+	jsStreamPeerLabels     = []string{"stream", "peer_name"}
+	jsConsumerLabels       = []string{"stream", "consumer_name"}
+	jsConsumerConfigLabels = []string{"stream", "consumer_name", "ack_policy", "is_pull"}
+	jsConsumerPeerLabels   = []string{"stream", "consumer_name", "peer_name"}
+)
 
-type JSStreamConfigMetrics struct {
-	jsStreamConfig           *prometheus.GaugeVec
-	jsStreamRaftInfo         *prometheus.GaugeVec
-	jsStreamRaftPeerInfo     *prometheus.GaugeVec
-	jsStreamReplicationLag   *prometheus.GaugeVec
-	jsStreamStateConsumerNum *prometheus.GaugeVec
-	jsStreamStateDeletedNum  *prometheus.GaugeVec
-	jsStreamStateSubjectNum  *prometheus.GaugeVec
+// JSConfigMetrics are the metrics exported by the JetStream configuration
+// listener. They deliberately only cover what the jsz collector does not
+// already export: stream and consumer configuration, per-asset limits and
+// per-peer Raft health.
+type JSConfigMetrics struct {
+	jsConfigPollErrors *CounterVec
 
-	jsConsumerConfig                *prometheus.GaugeVec
-	jsConsumerState                 *prometheus.GaugeVec
-	jsConsumerRaftInfo              *prometheus.GaugeVec
-	jsConsumerRaftPeerInfo          *prometheus.GaugeVec
-	jsConsumerReplicationLag        *prometheus.GaugeVec
-	jsConsumerAckPendingNum         *prometheus.GaugeVec
-	jsConsumerPendingNum            *prometheus.GaugeVec
-	jsConsumerRedeliveredNum        *prometheus.GaugeVec
-	jsConsumerWaitingNum            *prometheus.GaugeVec
-	jsConsumerLastAckFloorConsumer  *prometheus.GaugeVec
-	jsConsumerLastAckFloorStream    *prometheus.GaugeVec
-	jsConsumerLastDeliveredConsumer *prometheus.GaugeVec
-	jsConsumerLastDeliveredStream   *prometheus.GaugeVec
+	jsStreamConfig            *GaugeVec
+	jsStreamDeletedCount      *GaugeVec
+	jsStreamLimitMaxMsgs      *GaugeVec
+	jsStreamLimitMaxMsgsPer   *GaugeVec
+	jsStreamLimitMaxBytes     *GaugeVec
+	jsStreamLimitMaxAge       *GaugeVec
+	jsStreamLimitMaxMsgSize   *GaugeVec
+	jsStreamLimitMaxConsumers *GaugeVec
+	jsStreamPeerLeader        *GaugeVec
+	jsStreamPeerCurrent       *GaugeVec
+	jsStreamPeerOffline       *GaugeVec
+	jsStreamReplicationLag    *GaugeVec
 
-	jsStreamLimitMaxMsgs      *prometheus.GaugeVec
-	jsStreamLimitMaxMsgsPer   *prometheus.GaugeVec
-	jsStreamLimitMaxBytes     *prometheus.GaugeVec
-	jsStreamLimitMaxAge       *prometheus.GaugeVec
-	jsStreamLimitMaxMsgSize   *prometheus.GaugeVec
-	jsStreamLimitMaxConsumers *prometheus.GaugeVec
+	jsConsumerConfig             *GaugeVec
+	jsConsumerLimitMaxAckPending *GaugeVec
+	jsConsumerPeerLeader         *GaugeVec
+	jsConsumerPeerCurrent        *GaugeVec
+	jsConsumerPeerOffline        *GaugeVec
+	jsConsumerReplicationLag     *GaugeVec
 }
 
-func NewJetStreamConfigListMetrics(registry *prometheus.Registry, constLabels prometheus.Labels) *JSStreamConfigMetrics {
-	metrics := &JSStreamConfigMetrics{
-		// API Audit
-		jsStreamConfig: prometheus.NewGaugeVec(prometheus.GaugeOpts{
-			Name:        prometheus.BuildFQName("nats", "jetstream", "stream_configuration"),
-			Help:        "Configurations for streams",
-			ConstLabels: constLabels,
-		}, streamConfigLabels),
-		jsConsumerConfig: prometheus.NewGaugeVec(prometheus.GaugeOpts{
-			Name:        prometheus.BuildFQName("nats", "jetstream", "consumer_configuration"),
-			Help:        "Configurations for consumer",
-			ConstLabels: constLabels,
-		}, consumerConfigLabels),
-		jsConsumerState: prometheus.NewGaugeVec(prometheus.GaugeOpts{
-			Name:        prometheus.BuildFQName("nats", "jetstream", "consumer_state"),
-			Help:        "state of consumer consumer",
-			ConstLabels: constLabels,
-		}, consumerStateLabels),
-		jsStreamRaftInfo: prometheus.NewGaugeVec(prometheus.GaugeOpts{
-			Name:        prometheus.BuildFQName("nats", "jetstream", "stream_raft_info"),
-			Help:        "raft info for streams",
-			ConstLabels: constLabels,
-		}, streamRaftInfoLabels),
-		jsStreamRaftPeerInfo: prometheus.NewGaugeVec(prometheus.GaugeOpts{
-			Name:        prometheus.BuildFQName("nats", "jetstream", "stream_raft_peer_info"),
-			Help:        "raft peer info for streams",
-			ConstLabels: constLabels,
-		}, streamRaftPeerInfoLabels),
-		jsStreamStateConsumerNum: prometheus.NewGaugeVec(prometheus.GaugeOpts{
-			Name:        prometheus.BuildFQName("nats", "jetstream", "stream_consumer_number"),
-			Help:        "consumer number of stream",
-			ConstLabels: constLabels,
-		}, streamLabel),
-		jsStreamStateDeletedNum: prometheus.NewGaugeVec(prometheus.GaugeOpts{
-			Name:        prometheus.BuildFQName("nats", "jetstream", "stream_deleted_number"),
-			Help:        "deleted number of stream",
-			ConstLabels: constLabels,
-		}, streamLabel),
-		jsStreamStateSubjectNum: prometheus.NewGaugeVec(prometheus.GaugeOpts{
-			Name:        prometheus.BuildFQName("nats", "jetstream", "stream_subject_number"),
-			Help:        "subject number for streams",
-			ConstLabels: constLabels,
-		}, streamLabel),
-		jsConsumerRaftInfo: prometheus.NewGaugeVec(prometheus.GaugeOpts{
-			Name:        prometheus.BuildFQName("nats", "jetstream", "consumer_raft_info"),
-			Help:        "raft info for consumer",
-			ConstLabels: constLabels,
-		}, consumerRaftInfoLabels),
-		jsConsumerRaftPeerInfo: prometheus.NewGaugeVec(prometheus.GaugeOpts{
-			Name:        prometheus.BuildFQName("nats", "jetstream", "consumer_raft_peer_info"),
-			Help:        "raft peer info for consumer",
-			ConstLabels: constLabels,
-		}, consumerRaftPeerInfoLabels),
-		jsStreamReplicationLag: prometheus.NewGaugeVec(prometheus.GaugeOpts{
-			Name:        prometheus.BuildFQName("nats", "jetstream", "stream_replication_lag"),
-			Help:        "replication lag of stream peers",
-			ConstLabels: constLabels,
-		}, streamReplicationLagLabels),
-		jsConsumerReplicationLag: prometheus.NewGaugeVec(prometheus.GaugeOpts{
-			Name:        prometheus.BuildFQName("nats", "jetstream", "consumer_replication_lag"),
-			Help:        "replication lag of consumer peers",
-			ConstLabels: constLabels,
-		}, consumerReplicationLagLabels),
-		jsConsumerAckPendingNum: prometheus.NewGaugeVec(prometheus.GaugeOpts{
-			Name:        prometheus.BuildFQName("nats", "jetstream", "consumer_ack_pending_number"),
-			Help:        "pending ack number of consumer",
-			ConstLabels: constLabels,
-		}, consumerStreamLabel),
-		jsConsumerPendingNum: prometheus.NewGaugeVec(prometheus.GaugeOpts{
-			Name:        prometheus.BuildFQName("nats", "jetstream", "consumer_pending_number"),
-			Help:        "pending number of consumer",
-			ConstLabels: constLabels,
-		}, consumerStreamLabel),
-		jsConsumerRedeliveredNum: prometheus.NewGaugeVec(prometheus.GaugeOpts{
-			Name:        prometheus.BuildFQName("nats", "jetstream", "consumer_redelivered_number"),
-			Help:        "redelivered number of consumer",
-			ConstLabels: constLabels,
-		}, consumerStreamLabel),
-		jsConsumerWaitingNum: prometheus.NewGaugeVec(prometheus.GaugeOpts{
-			Name:        prometheus.BuildFQName("nats", "jetstream", "consumer_waiting_number"),
-			Help:        "waiting number of consumer",
-			ConstLabels: constLabels,
-		}, consumerStreamLabel),
-		jsConsumerLastAckFloorConsumer: prometheus.NewGaugeVec(prometheus.GaugeOpts{
-			Name:        prometheus.BuildFQName("nats", "jetstream", "consumer_last_ack_floor_consumer_seq"),
-			Help:        "Consumer-scoped sequence number of the last acknowledged message",
-			ConstLabels: constLabels,
-		}, consumerStreamLabel),
-		jsConsumerLastAckFloorStream: prometheus.NewGaugeVec(prometheus.GaugeOpts{
-			Name:        prometheus.BuildFQName("nats", "jetstream", "consumer_last_ack_floor_stream_seq"),
-			Help:        "Stream-scoped sequence number of the last acknowledged message",
-			ConstLabels: constLabels,
-		}, consumerStreamLabel),
-		jsConsumerLastDeliveredConsumer: prometheus.NewGaugeVec(prometheus.GaugeOpts{
-			Name:        prometheus.BuildFQName("nats", "jetstream", "consumer_last_delivered_consumer_seq"),
-			Help:        "Consumer-scoped sequence number of the last delivered message",
-			ConstLabels: constLabels,
-		}, consumerStreamLabel),
-		jsConsumerLastDeliveredStream: prometheus.NewGaugeVec(prometheus.GaugeOpts{
-			Name:        prometheus.BuildFQName("nats", "jetstream", "consumer_last_delivered_stream_seq"),
-			Help:        "Stream-scoped sequence number of the last delivered message",
-			ConstLabels: constLabels,
-		}, consumerStreamLabel),
-		jsStreamLimitMaxMsgs: prometheus.NewGaugeVec(prometheus.GaugeOpts{
-			Name:        prometheus.BuildFQName("nats", "jetstream", "stream_limit_max_msgs"),
-			Help:        "Maximum number of messages allowed in the stream (-1 for unlimited)",
-			ConstLabels: constLabels,
-		}, streamLabel),
-		jsStreamLimitMaxMsgsPer: prometheus.NewGaugeVec(prometheus.GaugeOpts{
-			Name:        prometheus.BuildFQName("nats", "jetstream", "stream_limit_max_msgs_per_subject"),
-			Help:        "Maximum number of messages per subject allowed in the stream (-1 for unlimited)",
-			ConstLabels: constLabels,
-		}, streamLabel),
-		jsStreamLimitMaxBytes: prometheus.NewGaugeVec(prometheus.GaugeOpts{
-			Name:        prometheus.BuildFQName("nats", "jetstream", "stream_limit_max_bytes"),
-			Help:        "Maximum total bytes allowed in the stream (-1 for unlimited)",
-			ConstLabels: constLabels,
-		}, streamLabel),
-		jsStreamLimitMaxAge: prometheus.NewGaugeVec(prometheus.GaugeOpts{
-			Name:        prometheus.BuildFQName("nats", "jetstream", "stream_limit_max_age_seconds"),
-			Help:        "Maximum age of messages in seconds (0 for unlimited)",
-			ConstLabels: constLabels,
-		}, streamLabel),
-		jsStreamLimitMaxMsgSize: prometheus.NewGaugeVec(prometheus.GaugeOpts{
-			Name:        prometheus.BuildFQName("nats", "jetstream", "stream_limit_max_msg_size"),
-			Help:        "Maximum message size in bytes (-1 for unlimited)",
-			ConstLabels: constLabels,
-		}, streamLabel),
-		jsStreamLimitMaxConsumers: prometheus.NewGaugeVec(prometheus.GaugeOpts{
-			Name:        prometheus.BuildFQName("nats", "jetstream", "stream_limit_max_consumers"),
-			Help:        "Maximum number of consumers allowed (-1 for unlimited)",
-			ConstLabels: constLabels,
-		}, streamLabel),
+// NewJetStreamConfigMetrics creates and registers the metrics used by the
+// JetStream configuration listener.
+func NewJetStreamConfigMetrics(registry *prometheus.Registry, constLabels prometheus.Labels) *JSConfigMetrics {
+	metrics := &JSConfigMetrics{
+		jsConfigPollErrors: newCounterVec(
+			prometheus.BuildFQName("nats", "jetstream", "config_poll_errors"),
+			"Number of JetStream API requests that failed while polling configuration",
+			constLabels,
+			[]string{"operation"},
+		),
+
+		// Streams
+		jsStreamConfig: newGaugeVec(
+			prometheus.BuildFQName("nats", "jetstream", "stream_configuration"),
+			"Configuration of a stream, always 1, the configuration is in the labels",
+			constLabels,
+			jsStreamConfigLabels,
+		),
+
+		jsStreamDeletedCount: newGaugeVec(
+			prometheus.BuildFQName("nats", "jetstream", "stream_deleted_count"),
+			"Number of messages deleted from a stream out of sequence order",
+			constLabels,
+			jsStreamLabels,
+		),
+
+		jsStreamLimitMaxMsgs: newGaugeVec(
+			prometheus.BuildFQName("nats", "jetstream", "stream_limit_max_msgs"),
+			"Maximum number of messages a stream will store, -1 for unlimited",
+			constLabels,
+			jsStreamLabels,
+		),
+
+		jsStreamLimitMaxMsgsPer: newGaugeVec(
+			prometheus.BuildFQName("nats", "jetstream", "stream_limit_max_msgs_per_subject"),
+			"Maximum number of messages per subject a stream will store, -1 for unlimited",
+			constLabels,
+			jsStreamLabels,
+		),
+
+		jsStreamLimitMaxBytes: newGaugeVec(
+			prometheus.BuildFQName("nats", "jetstream", "stream_limit_max_bytes"),
+			"Maximum number of bytes a stream will store, -1 for unlimited",
+			constLabels,
+			jsStreamLabels,
+		),
+
+		jsStreamLimitMaxAge: newGaugeVec(
+			prometheus.BuildFQName("nats", "jetstream", "stream_limit_max_age_seconds"),
+			"Maximum age of messages a stream will retain in seconds, 0 for unlimited",
+			constLabels,
+			jsStreamLabels,
+		),
+
+		jsStreamLimitMaxMsgSize: newGaugeVec(
+			prometheus.BuildFQName("nats", "jetstream", "stream_limit_max_msg_size"),
+			"Maximum size of a single message in bytes, -1 for unlimited",
+			constLabels,
+			jsStreamLabels,
+		),
+
+		jsStreamLimitMaxConsumers: newGaugeVec(
+			prometheus.BuildFQName("nats", "jetstream", "stream_limit_max_consumers"),
+			"Maximum number of consumers allowed on a stream, -1 for unlimited",
+			constLabels,
+			jsStreamLabels,
+		),
+
+		jsStreamPeerLeader: newGaugeVec(
+			prometheus.BuildFQName("nats", "jetstream", "stream_peer_leader"),
+			"Whether a peer is the Raft leader of a stream",
+			constLabels,
+			jsStreamPeerLabels,
+		),
+
+		jsStreamPeerCurrent: newGaugeVec(
+			prometheus.BuildFQName("nats", "jetstream", "stream_peer_current"),
+			"Whether a peer is up to date with the Raft leader of a stream",
+			constLabels,
+			jsStreamPeerLabels,
+		),
+
+		jsStreamPeerOffline: newGaugeVec(
+			prometheus.BuildFQName("nats", "jetstream", "stream_peer_offline"),
+			"Whether a peer of a stream is considered offline by its Raft group",
+			constLabels,
+			jsStreamPeerLabels,
+		),
+
+		jsStreamReplicationLag: newGaugeVec(
+			prometheus.BuildFQName("nats", "jetstream", "stream_replication_lag"),
+			"Number of operations a peer of a stream is behind its Raft leader",
+			constLabels,
+			jsStreamPeerLabels,
+		),
+
+		// Consumers
+		jsConsumerConfig: newGaugeVec(
+			prometheus.BuildFQName("nats", "jetstream", "consumer_configuration"),
+			"Configuration of a consumer, always 1, the configuration is in the labels",
+			constLabels,
+			jsConsumerConfigLabels,
+		),
+
+		jsConsumerLimitMaxAckPending: newGaugeVec(
+			prometheus.BuildFQName("nats", "jetstream", "consumer_limit_max_ack_pending"),
+			"Maximum number of outstanding unacknowledged messages of a consumer",
+			constLabels,
+			jsConsumerLabels,
+		),
+
+		jsConsumerPeerLeader: newGaugeVec(
+			prometheus.BuildFQName("nats", "jetstream", "consumer_peer_leader"),
+			"Whether a peer is the Raft leader of a consumer",
+			constLabels,
+			jsConsumerPeerLabels,
+		),
+
+		jsConsumerPeerCurrent: newGaugeVec(
+			prometheus.BuildFQName("nats", "jetstream", "consumer_peer_current"),
+			"Whether a peer is up to date with the Raft leader of a consumer",
+			constLabels,
+			jsConsumerPeerLabels,
+		),
+
+		jsConsumerPeerOffline: newGaugeVec(
+			prometheus.BuildFQName("nats", "jetstream", "consumer_peer_offline"),
+			"Whether a peer of a consumer is considered offline by its Raft group",
+			constLabels,
+			jsConsumerPeerLabels,
+		),
+
+		jsConsumerReplicationLag: newGaugeVec(
+			prometheus.BuildFQName("nats", "jetstream", "consumer_replication_lag"),
+			"Number of operations a peer of a consumer is behind its Raft leader",
+			constLabels,
+			jsConsumerPeerLabels,
+		),
 	}
 
+	registry.MustRegister(metrics.jsConfigPollErrors)
+
 	registry.MustRegister(metrics.jsStreamConfig)
-	registry.MustRegister(metrics.jsConsumerConfig)
-	registry.MustRegister(metrics.jsConsumerState)
-	registry.MustRegister(metrics.jsStreamRaftInfo)
-	registry.MustRegister(metrics.jsStreamRaftPeerInfo)
-	registry.MustRegister(metrics.jsStreamStateSubjectNum)
-	registry.MustRegister(metrics.jsStreamStateDeletedNum)
-	registry.MustRegister(metrics.jsStreamStateConsumerNum)
-
-	registry.MustRegister(metrics.jsConsumerRaftInfo)
-	registry.MustRegister(metrics.jsConsumerRaftPeerInfo)
-	registry.MustRegister(metrics.jsStreamReplicationLag)
-	registry.MustRegister(metrics.jsConsumerReplicationLag)
-	registry.MustRegister(metrics.jsConsumerWaitingNum)
-	registry.MustRegister(metrics.jsConsumerAckPendingNum)
-	registry.MustRegister(metrics.jsConsumerPendingNum)
-	registry.MustRegister(metrics.jsConsumerRedeliveredNum)
-	registry.MustRegister(metrics.jsConsumerLastDeliveredConsumer)
-	registry.MustRegister(metrics.jsConsumerLastDeliveredStream)
-	registry.MustRegister(metrics.jsConsumerLastAckFloorConsumer)
-	registry.MustRegister(metrics.jsConsumerLastAckFloorStream)
-
+	registry.MustRegister(metrics.jsStreamDeletedCount)
 	registry.MustRegister(metrics.jsStreamLimitMaxMsgs)
 	registry.MustRegister(metrics.jsStreamLimitMaxMsgsPer)
 	registry.MustRegister(metrics.jsStreamLimitMaxBytes)
 	registry.MustRegister(metrics.jsStreamLimitMaxAge)
 	registry.MustRegister(metrics.jsStreamLimitMaxMsgSize)
 	registry.MustRegister(metrics.jsStreamLimitMaxConsumers)
+	registry.MustRegister(metrics.jsStreamPeerLeader)
+	registry.MustRegister(metrics.jsStreamPeerCurrent)
+	registry.MustRegister(metrics.jsStreamPeerOffline)
+	registry.MustRegister(metrics.jsStreamReplicationLag)
+
+	registry.MustRegister(metrics.jsConsumerConfig)
+	registry.MustRegister(metrics.jsConsumerLimitMaxAckPending)
+	registry.MustRegister(metrics.jsConsumerPeerLeader)
+	registry.MustRegister(metrics.jsConsumerPeerCurrent)
+	registry.MustRegister(metrics.jsConsumerPeerOffline)
+	registry.MustRegister(metrics.jsConsumerReplicationLag)
 
 	return metrics
 }
 
-// jsConfigListListener polls JetStream stream/consumer configuration and state on an
-// interval and exposes the result as prometheus metrics.
-type jsConfigListListener struct {
+// MetricInfos returns metadata about the metrics used by JSConfigMetrics
+func (m *JSConfigMetrics) MetricInfos() []MetricInfo {
+	return []MetricInfo{
+		m.jsConfigPollErrors,
+		m.jsStreamConfig,
+		m.jsStreamDeletedCount,
+		m.jsStreamLimitMaxMsgs,
+		m.jsStreamLimitMaxMsgsPer,
+		m.jsStreamLimitMaxBytes,
+		m.jsStreamLimitMaxAge,
+		m.jsStreamLimitMaxMsgSize,
+		m.jsStreamLimitMaxConsumers,
+		m.jsStreamPeerLeader,
+		m.jsStreamPeerCurrent,
+		m.jsStreamPeerOffline,
+		m.jsStreamReplicationLag,
+		m.jsConsumerConfig,
+		m.jsConsumerLimitMaxAckPending,
+		m.jsConsumerPeerLeader,
+		m.jsConsumerPeerCurrent,
+		m.jsConsumerPeerOffline,
+		m.jsConsumerReplicationLag,
+	}
+}
+
+// consumerKey identifies a consumer across polls.
+type consumerKey struct {
+	stream   string
+	consumer string
+}
+
+// peerKey identifies a member of a stream or consumer Raft group across polls.
+// consumer is empty for stream peers.
+type peerKey struct {
+	stream   string
+	consumer string
+	peer     string
+}
+
+// pollState records everything a single poll observed, so that assets which
+// disappeared since the previous poll can have their series removed instead of
+// reporting their last known value forever.
+type pollState struct {
+	streams       map[string]struct{}
+	streamPeers   map[peerKey]struct{}
+	consumers     map[consumerKey]struct{}
+	consumerPeers map[peerKey]struct{}
+}
+
+func newPollState() *pollState {
+	return &pollState{
+		streams:       make(map[string]struct{}),
+		streamPeers:   make(map[peerKey]struct{}),
+		consumers:     make(map[consumerKey]struct{}),
+		consumerPeers: make(map[peerKey]struct{}),
+	}
+}
+
+// jsConfigListener polls JetStream stream and consumer configuration and Raft
+// state on an interval and exposes the result as prometheus metrics.
+type jsConfigListener struct {
 	sync.Mutex
 	cancelLoop context.CancelFunc
 	wg         sync.WaitGroup
 	provider   ConnProvider
 	logger     *logrus.Logger
-	metrics    *JSStreamConfigMetrics
+	metrics    *JSConfigMetrics
 	interval   time.Duration
 	conn       Conn
-	js         nats.JetStreamContext
+	js         jetstream.JetStream
+
+	// streams caches stream handles so that listing the consumers of a known
+	// stream does not cost an extra STREAM.INFO request on every poll.
+	streams map[string]jetstream.Stream
+
+	// prev is what the previous complete poll observed.
+	prev *pollState
 }
 
-func NewJetStreamConfigListener(provider ConnProvider, logger *logrus.Logger, metrics *JSStreamConfigMetrics, interval time.Duration) *jsConfigListListener {
-	if interval <= 0 {
-		interval = DefaultJSConfigPollInterval
+func newJetStreamConfigListener(provider ConnProvider, logger *logrus.Logger, metrics *JSConfigMetrics, interval time.Duration) (*jsConfigListener, error) {
+	if interval < MinJSConfigPollInterval {
+		return nil, fmt.Errorf("jetstream config poll interval %s is below the %s minimum", interval, MinJSConfigPollInterval)
 	}
-	return &jsConfigListListener{
+	return &jsConfigListener{
 		provider: provider,
 		logger:   logger,
 		metrics:  metrics,
 		interval: interval,
-	}
+		streams:  make(map[string]jetstream.Stream),
+		prev:     newPollState(),
+	}, nil
 }
 
-func (o *jsConfigListListener) gatherData(ctx context.Context, interval time.Duration) {
-	defer o.wg.Done()
-	ticker := time.NewTicker(interval)
-	defer ticker.Stop()
-	o.logger.Infof("starting JetStream config poll loop (interval=%s)", interval)
-	for {
-		select {
-		case <-ticker.C:
-			// Snapshot js under the lock to avoid holding it across blocking NATS I/O.
-			o.Lock()
-			js := o.js
-			o.Unlock()
-			if js == nil || ctx.Err() != nil {
-				return
-			}
-			for str := range js.Streams() {
-				if ctx.Err() != nil {
-					return
-				}
-				o.StreamHandler(str)
-				for con := range js.Consumers(str.Config.Name) {
-					if ctx.Err() != nil {
-						return
-					}
-					o.ConsumerHandler(con)
-				}
-			}
-		case <-ctx.Done():
-			o.logger.Debugln("stopping JetStream config poll loop")
-			return
-		}
-	}
-}
-
-func (o *jsConfigListListener) Start(natsCtx *NatsContext) error {
+// Start connects to NATS and starts the polling loop.
+func (o *jsConfigListener) Start(natsCtx *NatsContext) error {
 	o.Lock()
 	defer o.Unlock()
 	if o.conn != nil {
@@ -311,259 +343,38 @@ func (o *jsConfigListListener) Start(natsCtx *NatsContext) error {
 	}
 	conn, err := o.provider.Get(natsCtx)
 	if err != nil {
-		return fmt.Errorf("nats connection failed: %v", err)
+		return fmt.Errorf("nats connection failed: %w", err)
 	}
-	o.conn = conn
-	js, err := conn.Conn().JetStream()
+	js, err := jetstream.New(conn.Conn())
 	if err != nil {
-		o.conn.Close()
-		o.conn = nil
-		return fmt.Errorf("failed to create jetstream context: %v", err)
+		conn.Close()
+		return fmt.Errorf("failed to create jetstream context: %w", err)
 	}
-	o.js = js
-	ctx, cancelFunc := context.WithCancel(context.Background())
 
+	// Creating the context does not talk to the server, so probe the API
+	// before reporting success. The surveyor normally runs as the system
+	// account, which cannot use the JetStream API at all, and without this
+	// check that misconfiguration would only show up as permanently missing
+	// metrics.
+	probeCtx, cancelProbe := context.WithTimeout(context.Background(), jsConfigProbeTimeout)
+	defer cancelProbe()
+	if _, err := js.AccountInfo(probeCtx); err != nil {
+		conn.Close()
+		return fmt.Errorf("jetstream api is unavailable to the configured credentials: %w", err)
+	}
+
+	o.conn = conn
+	o.js = js
+
+	ctx, cancelFunc := context.WithCancel(context.Background())
 	o.cancelLoop = cancelFunc
 	o.wg.Add(1)
-	go o.gatherData(ctx, o.interval)
+	go o.loop(ctx)
 	return nil
 }
 
-func (o *jsConfigListListener) StreamHandler(streamInfo *nats.StreamInfo) {
-	if streamInfo == nil {
-		o.logger.Infof("received empty stream")
-		return
-	}
-	o.metrics.jsStreamConfig.DeletePartialMatch(prometheus.Labels{
-		"stream_name": streamInfo.Config.Name,
-	})
-
-	o.metrics.jsStreamConfig.With(
-		prometheus.Labels{
-			"discard_policy": streamInfo.Config.Discard.String(),
-			"storage_type":   streamInfo.Config.Storage.String(),
-			"replica_number": strconv.Itoa(streamInfo.Config.Replicas),
-			"stream_name":    streamInfo.Config.Name,
-		},
-	).Set(1)
-
-	o.metrics.jsStreamRaftInfo.DeletePartialMatch(prometheus.Labels{
-		"stream_name": streamInfo.Config.Name,
-	})
-	o.metrics.jsStreamRaftPeerInfo.DeletePartialMatch(prometheus.Labels{
-		"stream_name": streamInfo.Config.Name,
-	})
-	o.metrics.jsStreamReplicationLag.DeletePartialMatch(
-		prometheus.Labels{
-			"stream_name": streamInfo.Config.Name,
-		},
-	)
-
-	if streamInfo.Cluster != nil {
-		o.metrics.jsStreamRaftInfo.With(
-			prometheus.Labels{
-				"stream_name":   streamInfo.Config.Name,
-				"leader":        streamInfo.Cluster.Leader,
-				"replica_count": strconv.Itoa(len(streamInfo.Cluster.Replicas)),
-			},
-		).Set(1)
-
-		for _, peer := range streamInfo.Cluster.Replicas {
-			o.metrics.jsStreamRaftPeerInfo.With(
-				prometheus.Labels{
-					"leader":      streamInfo.Cluster.Leader,
-					"stream_name": streamInfo.Config.Name,
-					"peer_name":   peer.Name,
-					"offline":     convertBoolToString(peer.Offline),
-					"current":     convertBoolToString(peer.Current),
-				},
-			).Set(1)
-
-			o.metrics.jsStreamReplicationLag.With(
-				prometheus.Labels{
-					"stream_name": streamInfo.Config.Name,
-					"peer_name":   peer.Name,
-				},
-			).Set(float64(peer.Lag))
-		}
-	}
-
-	o.metrics.jsStreamStateConsumerNum.DeletePartialMatch(prometheus.Labels{
-		"stream_name": streamInfo.Config.Name,
-	})
-	o.metrics.jsStreamStateSubjectNum.DeletePartialMatch(prometheus.Labels{
-		"stream_name": streamInfo.Config.Name,
-	})
-	o.metrics.jsStreamStateDeletedNum.DeletePartialMatch(prometheus.Labels{
-		"stream_name": streamInfo.Config.Name,
-	})
-
-	o.metrics.jsStreamStateSubjectNum.With(
-		prometheus.Labels{
-			"stream_name": streamInfo.Config.Name,
-		},
-	).Set(float64(streamInfo.State.NumSubjects))
-	o.metrics.jsStreamStateDeletedNum.With(
-		prometheus.Labels{
-			"stream_name": streamInfo.Config.Name,
-		},
-	).Set(float64(streamInfo.State.NumDeleted))
-	o.metrics.jsStreamStateConsumerNum.With(
-		prometheus.Labels{
-			"stream_name": streamInfo.Config.Name,
-		},
-	).Set(float64(streamInfo.State.Consumers))
-
-	// Stream Limits
-	o.metrics.jsStreamLimitMaxMsgs.DeletePartialMatch(prometheus.Labels{
-		"stream_name": streamInfo.Config.Name,
-	})
-	o.metrics.jsStreamLimitMaxMsgsPer.DeletePartialMatch(prometheus.Labels{
-		"stream_name": streamInfo.Config.Name,
-	})
-	o.metrics.jsStreamLimitMaxBytes.DeletePartialMatch(prometheus.Labels{
-		"stream_name": streamInfo.Config.Name,
-	})
-	o.metrics.jsStreamLimitMaxAge.DeletePartialMatch(prometheus.Labels{
-		"stream_name": streamInfo.Config.Name,
-	})
-	o.metrics.jsStreamLimitMaxMsgSize.DeletePartialMatch(prometheus.Labels{
-		"stream_name": streamInfo.Config.Name,
-	})
-	o.metrics.jsStreamLimitMaxConsumers.DeletePartialMatch(prometheus.Labels{
-		"stream_name": streamInfo.Config.Name,
-	})
-
-	o.metrics.jsStreamLimitMaxMsgs.With(
-		prometheus.Labels{
-			"stream_name": streamInfo.Config.Name,
-		},
-	).Set(float64(streamInfo.Config.MaxMsgs))
-
-	o.metrics.jsStreamLimitMaxMsgsPer.With(
-		prometheus.Labels{
-			"stream_name": streamInfo.Config.Name,
-		},
-	).Set(float64(streamInfo.Config.MaxMsgsPerSubject))
-
-	o.metrics.jsStreamLimitMaxBytes.With(
-		prometheus.Labels{
-			"stream_name": streamInfo.Config.Name,
-		},
-	).Set(float64(streamInfo.Config.MaxBytes))
-
-	o.metrics.jsStreamLimitMaxAge.With(
-		prometheus.Labels{
-			"stream_name": streamInfo.Config.Name,
-		},
-	).Set(streamInfo.Config.MaxAge.Seconds())
-
-	o.metrics.jsStreamLimitMaxMsgSize.With(
-		prometheus.Labels{
-			"stream_name": streamInfo.Config.Name,
-		},
-	).Set(float64(streamInfo.Config.MaxMsgSize))
-
-	o.metrics.jsStreamLimitMaxConsumers.With(
-		prometheus.Labels{
-			"stream_name": streamInfo.Config.Name,
-		},
-	).Set(float64(streamInfo.Config.MaxConsumers))
-}
-func convertBoolToString(value bool) string {
-	if value {
-		return "true"
-	}
-	return "false"
-}
-func (o *jsConfigListListener) ConsumerHandler(consumerInfo *nats.ConsumerInfo) {
-	if consumerInfo == nil {
-		o.logger.Infof("received empty consumer")
-		return
-	}
-	consumerLabels := prometheus.Labels{
-		"stream_name":   consumerInfo.Stream,
-		"consumer_name": consumerInfo.Name,
-	}
-
-	o.metrics.jsConsumerConfig.DeletePartialMatch(consumerLabels)
-	o.metrics.jsConsumerConfig.With(
-		prometheus.Labels{
-			"stream_name":     consumerInfo.Stream,
-			"consumer_name":   consumerInfo.Name,
-			"max_pending_ack": strconv.Itoa(consumerInfo.Config.MaxAckPending),
-			"ack_policy":      consumerInfo.Config.AckPolicy.String(),
-			"is_pull":         IsPullBased(consumerInfo),
-		},
-	).Set(1)
-
-	o.metrics.jsConsumerState.DeletePartialMatch(consumerLabels)
-	o.metrics.jsConsumerState.With(consumerLabels).Set(1)
-
-	o.metrics.jsConsumerWaitingNum.DeletePartialMatch(consumerLabels)
-	o.metrics.jsConsumerPendingNum.DeletePartialMatch(consumerLabels)
-	o.metrics.jsConsumerAckPendingNum.DeletePartialMatch(consumerLabels)
-	o.metrics.jsConsumerRedeliveredNum.DeletePartialMatch(consumerLabels)
-	o.metrics.jsConsumerLastDeliveredConsumer.DeletePartialMatch(consumerLabels)
-	o.metrics.jsConsumerLastDeliveredStream.DeletePartialMatch(consumerLabels)
-	o.metrics.jsConsumerLastAckFloorConsumer.DeletePartialMatch(consumerLabels)
-	o.metrics.jsConsumerLastAckFloorStream.DeletePartialMatch(consumerLabels)
-
-	o.metrics.jsConsumerWaitingNum.With(consumerLabels).Set(float64(consumerInfo.NumWaiting))
-	o.metrics.jsConsumerPendingNum.With(consumerLabels).Set(float64(consumerInfo.NumPending))
-	o.metrics.jsConsumerAckPendingNum.With(consumerLabels).Set(float64(consumerInfo.NumAckPending))
-	o.metrics.jsConsumerRedeliveredNum.With(consumerLabels).Set(float64(consumerInfo.NumRedelivered))
-	o.metrics.jsConsumerLastDeliveredConsumer.With(consumerLabels).Set(float64(consumerInfo.Delivered.Consumer))
-	o.metrics.jsConsumerLastDeliveredStream.With(consumerLabels).Set(float64(consumerInfo.Delivered.Stream))
-	o.metrics.jsConsumerLastAckFloorConsumer.With(consumerLabels).Set(float64(consumerInfo.AckFloor.Consumer))
-	o.metrics.jsConsumerLastAckFloorStream.With(consumerLabels).Set(float64(consumerInfo.AckFloor.Stream))
-
-	o.metrics.jsConsumerRaftInfo.DeletePartialMatch(consumerLabels)
-	o.metrics.jsConsumerRaftPeerInfo.DeletePartialMatch(consumerLabels)
-	o.metrics.jsConsumerReplicationLag.DeletePartialMatch(consumerLabels)
-
-	if consumerInfo.Cluster == nil {
-		// non-clustered (single-server or R1) deployment — no raft/peer data
-		return
-	}
-	o.metrics.jsConsumerRaftInfo.With(
-		prometheus.Labels{
-			"consumer_name": consumerInfo.Name,
-			"stream_name":   consumerInfo.Stream,
-			"leader":        consumerInfo.Cluster.Leader,
-			"replica_count": strconv.Itoa(len(consumerInfo.Cluster.Replicas)),
-		},
-	).Set(1)
-	for _, peer := range consumerInfo.Cluster.Replicas {
-		o.metrics.jsConsumerRaftPeerInfo.With(
-			prometheus.Labels{
-				"leader":        consumerInfo.Cluster.Leader,
-				"stream_name":   consumerInfo.Stream,
-				"consumer_name": consumerInfo.Name,
-				"peer_name":     peer.Name,
-				"offline":       convertBoolToString(peer.Offline),
-				"current":       convertBoolToString(peer.Current),
-			},
-		).Set(1)
-		o.metrics.jsConsumerReplicationLag.With(
-			prometheus.Labels{
-				"stream_name":   consumerInfo.Stream,
-				"consumer_name": consumerInfo.Name,
-				"peer_name":     peer.Name,
-			},
-		).Set(float64(peer.Lag))
-	}
-}
-func IsPullBased(info *nats.ConsumerInfo) string {
-	isPull := info.Config.DeliverGroup == "" && info.Config.DeliverSubject == ""
-	if isPull {
-		return "true"
-	}
-	return "false"
-}
-
 // Stop stops the JetStream config polling loop.
-func (o *jsConfigListListener) Stop() {
+func (o *jsConfigListener) Stop() {
 	o.Lock()
 	if o.conn == nil {
 		// already stopped
@@ -583,4 +394,272 @@ func (o *jsConfigListListener) Stop() {
 		o.js = nil
 	}
 	o.Unlock()
+}
+
+func (o *jsConfigListener) loop(ctx context.Context) {
+	defer o.wg.Done()
+	o.logger.Infof("Starting JetStream config poll loop, interval %s", o.interval)
+
+	// A timer rather than a ticker: it is armed again only once a poll has
+	// completed, so a poll that outruns the interval delays the next one
+	// instead of being followed immediately by a queued tick. The zero delay
+	// polls once right away rather than leaving metrics empty for a full
+	// interval after startup.
+	timer := time.NewTimer(0)
+	defer timer.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			o.logger.Debugln("Stopping JetStream config poll loop")
+			return
+		case <-timer.C:
+			o.poll(ctx)
+			timer.Reset(o.interval)
+		}
+	}
+}
+
+// poll walks every stream and its consumers once and updates the metrics.
+func (o *jsConfigListener) poll(ctx context.Context) {
+	o.Lock()
+	js := o.js
+	o.Unlock()
+	if js == nil {
+		return
+	}
+
+	state := newPollState()
+	streams := js.ListStreams(ctx)
+	for info := range streams.Info() {
+		if info == nil {
+			o.logger.Warn("Received nil stream info")
+			continue
+		}
+		o.recordStream(info, state)
+
+		if info.State.Consumers == 0 {
+			// Nothing to list, and skipping the request spares the meta
+			// leader a scatter-gather over a stream with no consumers.
+			continue
+		}
+		if err := o.pollConsumers(ctx, js, info.Config.Name, state); err != nil {
+			if ctx.Err() != nil {
+				return
+			}
+			o.metrics.jsConfigPollErrors.WithLabelValues("list_consumers").Inc()
+			o.logger.Warnf("Could not list consumers of stream %s: %s", info.Config.Name, err)
+			// The consumers of this stream are unknown this cycle, so keep
+			// whatever the previous poll saw rather than deleting it below.
+			o.carryOverConsumers(info.Config.Name, state)
+		}
+	}
+	if err := streams.Err(); err != nil {
+		if ctx.Err() == nil {
+			o.metrics.jsConfigPollErrors.WithLabelValues("list_streams").Inc()
+			o.logger.Warnf("Could not list JetStream streams: %s", err)
+		}
+		// The listing is incomplete, so it is impossible to tell an absent
+		// stream from an unreported one. Leave every series in place.
+		return
+	}
+
+	o.pruneStale(state)
+}
+
+func (o *jsConfigListener) pollConsumers(ctx context.Context, js jetstream.JetStream, stream string, state *pollState) error {
+	str, ok := o.streams[stream]
+	if !ok {
+		var err error
+		if str, err = js.Stream(ctx, stream); err != nil {
+			return err
+		}
+		o.streams[stream] = str
+	}
+
+	consumers := str.ListConsumers(ctx)
+	for info := range consumers.Info() {
+		if info == nil {
+			o.logger.Warn("Received nil consumer info")
+			continue
+		}
+		o.recordConsumer(info, state)
+	}
+	return consumers.Err()
+}
+
+// raftPeer is the per-peer view of a Raft group. The leader is included as a
+// peer of its own group: it is the server that answered the request, so it is
+// by definition online, current and not lagging, and without it there would be
+// no series saying which server leads the group.
+type raftPeer struct {
+	name    string
+	leader  bool
+	current bool
+	offline bool
+	lag     uint64
+}
+
+func raftPeers(cluster *jetstream.ClusterInfo) []raftPeer {
+	// Cluster is nil on a non-clustered deployment, where there is no Raft
+	// group to report on.
+	if cluster == nil {
+		return nil
+	}
+	peers := make([]raftPeer, 0, len(cluster.Replicas)+1)
+	if cluster.Leader != "" {
+		peers = append(peers, raftPeer{name: cluster.Leader, leader: true, current: true})
+	}
+	for _, replica := range cluster.Replicas {
+		peers = append(peers, raftPeer{
+			name:    replica.Name,
+			current: replica.Current,
+			offline: replica.Offline,
+			lag:     replica.Lag,
+		})
+	}
+	return peers
+}
+
+func boolToFloat(value bool) float64 {
+	if value {
+		return 1
+	}
+	return 0
+}
+
+func isPullBased(config jetstream.ConsumerConfig) bool {
+	return config.DeliverSubject == ""
+}
+
+func (o *jsConfigListener) recordStream(info *jetstream.StreamInfo, state *pollState) {
+	stream := info.Config.Name
+	state.streams[stream] = struct{}{}
+	labels := prometheus.Labels{"stream": stream}
+
+	// A stream update changes the label values of the configuration series, so
+	// the previous one has to be dropped. The gauges below are keyed by stream
+	// alone and are simply overwritten.
+	o.metrics.jsStreamConfig.DeletePartialMatch(labels)
+	o.metrics.jsStreamConfig.With(prometheus.Labels{
+		"stream":         stream,
+		"discard_policy": info.Config.Discard.String(),
+		"storage_type":   info.Config.Storage.String(),
+		"replica_number": strconv.Itoa(info.Config.Replicas),
+	}).Set(1)
+
+	o.metrics.jsStreamDeletedCount.With(labels).Set(float64(info.State.NumDeleted))
+	o.metrics.jsStreamLimitMaxMsgs.With(labels).Set(float64(info.Config.MaxMsgs))
+	o.metrics.jsStreamLimitMaxMsgsPer.With(labels).Set(float64(info.Config.MaxMsgsPerSubject))
+	o.metrics.jsStreamLimitMaxBytes.With(labels).Set(float64(info.Config.MaxBytes))
+	o.metrics.jsStreamLimitMaxAge.With(labels).Set(info.Config.MaxAge.Seconds())
+	o.metrics.jsStreamLimitMaxMsgSize.With(labels).Set(float64(info.Config.MaxMsgSize))
+	o.metrics.jsStreamLimitMaxConsumers.With(labels).Set(float64(info.Config.MaxConsumers))
+
+	for _, peer := range raftPeers(info.Cluster) {
+		state.streamPeers[peerKey{stream: stream, peer: peer.name}] = struct{}{}
+		peerLabels := prometheus.Labels{"stream": stream, "peer_name": peer.name}
+
+		o.metrics.jsStreamPeerLeader.With(peerLabels).Set(boolToFloat(peer.leader))
+		o.metrics.jsStreamPeerCurrent.With(peerLabels).Set(boolToFloat(peer.current))
+		o.metrics.jsStreamPeerOffline.With(peerLabels).Set(boolToFloat(peer.offline))
+		o.metrics.jsStreamReplicationLag.With(peerLabels).Set(float64(peer.lag))
+	}
+}
+
+func (o *jsConfigListener) recordConsumer(info *jetstream.ConsumerInfo, state *pollState) {
+	// Config.Name is empty for ephemeral consumers, Name always holds the name
+	// the server knows the consumer by.
+	stream, consumer := info.Stream, info.Name
+	state.consumers[consumerKey{stream: stream, consumer: consumer}] = struct{}{}
+	labels := prometheus.Labels{"stream": stream, "consumer_name": consumer}
+
+	o.metrics.jsConsumerConfig.DeletePartialMatch(labels)
+	o.metrics.jsConsumerConfig.With(prometheus.Labels{
+		"stream":        stream,
+		"consumer_name": consumer,
+		"ack_policy":    info.Config.AckPolicy.String(),
+		"is_pull":       strconv.FormatBool(isPullBased(info.Config)),
+	}).Set(1)
+
+	o.metrics.jsConsumerLimitMaxAckPending.With(labels).Set(float64(info.Config.MaxAckPending))
+
+	for _, peer := range raftPeers(info.Cluster) {
+		state.consumerPeers[peerKey{stream: stream, consumer: consumer, peer: peer.name}] = struct{}{}
+		peerLabels := prometheus.Labels{"stream": stream, "consumer_name": consumer, "peer_name": peer.name}
+
+		o.metrics.jsConsumerPeerLeader.With(peerLabels).Set(boolToFloat(peer.leader))
+		o.metrics.jsConsumerPeerCurrent.With(peerLabels).Set(boolToFloat(peer.current))
+		o.metrics.jsConsumerPeerOffline.With(peerLabels).Set(boolToFloat(peer.offline))
+		o.metrics.jsConsumerReplicationLag.With(peerLabels).Set(float64(peer.lag))
+	}
+}
+
+// carryOverConsumers copies the previous poll's view of a stream's consumers
+// into state, so that a failed consumer listing does not look like the
+// consumers were deleted.
+func (o *jsConfigListener) carryOverConsumers(stream string, state *pollState) {
+	for key := range o.prev.consumers {
+		if key.stream == stream {
+			state.consumers[key] = struct{}{}
+		}
+	}
+	for key := range o.prev.consumerPeers {
+		if key.stream == stream {
+			state.consumerPeers[key] = struct{}{}
+		}
+	}
+}
+
+// pruneStale removes the series of every asset that the previous poll saw and
+// this one did not, then remembers the new state.
+func (o *jsConfigListener) pruneStale(state *pollState) {
+	for stream := range o.prev.streams {
+		if _, ok := state.streams[stream]; ok {
+			continue
+		}
+		delete(o.streams, stream)
+		labels := prometheus.Labels{"stream": stream}
+		o.metrics.jsStreamConfig.DeletePartialMatch(labels)
+		o.metrics.jsStreamDeletedCount.Delete(labels)
+		o.metrics.jsStreamLimitMaxMsgs.Delete(labels)
+		o.metrics.jsStreamLimitMaxMsgsPer.Delete(labels)
+		o.metrics.jsStreamLimitMaxBytes.Delete(labels)
+		o.metrics.jsStreamLimitMaxAge.Delete(labels)
+		o.metrics.jsStreamLimitMaxMsgSize.Delete(labels)
+		o.metrics.jsStreamLimitMaxConsumers.Delete(labels)
+	}
+
+	for key := range o.prev.streamPeers {
+		if _, ok := state.streamPeers[key]; ok {
+			continue
+		}
+		labels := prometheus.Labels{"stream": key.stream, "peer_name": key.peer}
+		o.metrics.jsStreamPeerLeader.Delete(labels)
+		o.metrics.jsStreamPeerCurrent.Delete(labels)
+		o.metrics.jsStreamPeerOffline.Delete(labels)
+		o.metrics.jsStreamReplicationLag.Delete(labels)
+	}
+
+	for key := range o.prev.consumers {
+		if _, ok := state.consumers[key]; ok {
+			continue
+		}
+		labels := prometheus.Labels{"stream": key.stream, "consumer_name": key.consumer}
+		o.metrics.jsConsumerConfig.DeletePartialMatch(labels)
+		o.metrics.jsConsumerLimitMaxAckPending.Delete(labels)
+	}
+
+	for key := range o.prev.consumerPeers {
+		if _, ok := state.consumerPeers[key]; ok {
+			continue
+		}
+		labels := prometheus.Labels{"stream": key.stream, "consumer_name": key.consumer, "peer_name": key.peer}
+		o.metrics.jsConsumerPeerLeader.Delete(labels)
+		o.metrics.jsConsumerPeerCurrent.Delete(labels)
+		o.metrics.jsConsumerPeerOffline.Delete(labels)
+		o.metrics.jsConsumerReplicationLag.Delete(labels)
+	}
+
+	o.prev = state
 }

--- a/surveyor/jetstream_configs.go
+++ b/surveyor/jetstream_configs.go
@@ -30,10 +30,10 @@ var (
 	streamConfigLabels           = []string{"discard_policy", "storage_type", "replica_number", "stream_name"}
 	consumerConfigLabels         = []string{"stream_name", "max_pending_ack", "ack_policy", "is_pull", "consumer_name"}
 	streamRaftInfoLabels         = []string{"stream_name", "leader", "replica_count"}
-	streamRaftPeerInfoLabels     = []string{"stream_name", "peer_name", "offline", "current", "leader", "lag"}
+	streamRaftPeerInfoLabels     = []string{"stream_name", "peer_name", "offline", "current", "leader"}
 	consumerRaftInfoLabels       = []string{"consumer_name", "leader", "replica_count", "stream_name"}
-	consumerStateLabels          = []string{"consumer_name", "stream_name", "last_delivered_message_consumer", "last_delivered_message_stream", "ack_floor_consumer", "ack_floor_stream"}
-	consumerRaftPeerInfoLabels   = []string{"stream_name", "consumer_name", "peer_name", "offline", "current", "leader", "lag"}
+	consumerStateLabels          = []string{"consumer_name", "stream_name"}
+	consumerRaftPeerInfoLabels   = []string{"stream_name", "consumer_name", "peer_name", "offline", "current", "leader"}
 	streamReplicationLagLabels   = []string{"stream_name", "peer_name"}
 	consumerReplicationLagLabels = []string{"stream_name", "consumer_name", "peer_name"}
 	streamLabel                  = []string{"stream_name"}
@@ -53,17 +53,19 @@ type JSStreamConfigMetrics struct {
 	jsStreamStateDeletedNum  *prometheus.GaugeVec
 	jsStreamStateSubjectNum  *prometheus.GaugeVec
 
-	jsConsumerConfig              *prometheus.GaugeVec
-	jsConsumerState               *prometheus.GaugeVec
-	jsConsumerRaftInfo            *prometheus.GaugeVec
-	jsConsumerRaftPeerInfo        *prometheus.GaugeVec
-	jsConsumerReplicationLag      *prometheus.GaugeVec
-	jsConsumerAckPendingNum       *prometheus.GaugeVec
-	jsConsumerPendingNum          *prometheus.GaugeVec
-	jsConsumerRedeliveredNum      *prometheus.GaugeVec
-	jsConsumerWaitingNum          *prometheus.GaugeVec
-	jsConsumerLastAckFloorSecNum  *prometheus.GaugeVec
-	jsConsumerLastDeliveredSecNum *prometheus.GaugeVec
+	jsConsumerConfig                 *prometheus.GaugeVec
+	jsConsumerState                  *prometheus.GaugeVec
+	jsConsumerRaftInfo               *prometheus.GaugeVec
+	jsConsumerRaftPeerInfo           *prometheus.GaugeVec
+	jsConsumerReplicationLag         *prometheus.GaugeVec
+	jsConsumerAckPendingNum          *prometheus.GaugeVec
+	jsConsumerPendingNum             *prometheus.GaugeVec
+	jsConsumerRedeliveredNum         *prometheus.GaugeVec
+	jsConsumerWaitingNum             *prometheus.GaugeVec
+	jsConsumerLastAckFloorConsumer   *prometheus.GaugeVec
+	jsConsumerLastAckFloorStream     *prometheus.GaugeVec
+	jsConsumerLastDeliveredConsumer  *prometheus.GaugeVec
+	jsConsumerLastDeliveredStream    *prometheus.GaugeVec
 
 	jsStreamLimitMaxMsgs      *prometheus.GaugeVec
 	jsStreamLimitMaxMsgsPer   *prometheus.GaugeVec
@@ -156,14 +158,24 @@ func NewJetStreamConfigListMetrics(registry *prometheus.Registry, constLabels pr
 			Help:        "waiting number of consumer",
 			ConstLabels: constLabels,
 		}, consumerStreamLabel),
-		jsConsumerLastAckFloorSecNum: prometheus.NewGaugeVec(prometheus.GaugeOpts{
-			Name:        prometheus.BuildFQName("nats", "jetstream", "consumer_last_ack_floor_number"),
-			Help:        "last ack floor number of consumer",
+		jsConsumerLastAckFloorConsumer: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Name:        prometheus.BuildFQName("nats", "jetstream", "consumer_last_ack_floor_consumer_seq"),
+			Help:        "Consumer-scoped sequence number of the last acknowledged message",
 			ConstLabels: constLabels,
 		}, consumerStreamLabel),
-		jsConsumerLastDeliveredSecNum: prometheus.NewGaugeVec(prometheus.GaugeOpts{
-			Name:        prometheus.BuildFQName("nats", "jetstream", "consumer_last_delivered_number"),
-			Help:        "last delivered number of consumer",
+		jsConsumerLastAckFloorStream: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Name:        prometheus.BuildFQName("nats", "jetstream", "consumer_last_ack_floor_stream_seq"),
+			Help:        "Stream-scoped sequence number of the last acknowledged message",
+			ConstLabels: constLabels,
+		}, consumerStreamLabel),
+		jsConsumerLastDeliveredConsumer: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Name:        prometheus.BuildFQName("nats", "jetstream", "consumer_last_delivered_consumer_seq"),
+			Help:        "Consumer-scoped sequence number of the last delivered message",
+			ConstLabels: constLabels,
+		}, consumerStreamLabel),
+		jsConsumerLastDeliveredStream: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Name:        prometheus.BuildFQName("nats", "jetstream", "consumer_last_delivered_stream_seq"),
+			Help:        "Stream-scoped sequence number of the last delivered message",
 			ConstLabels: constLabels,
 		}, consumerStreamLabel),
 		jsStreamLimitMaxMsgs: prometheus.NewGaugeVec(prometheus.GaugeOpts{
@@ -215,8 +227,10 @@ func NewJetStreamConfigListMetrics(registry *prometheus.Registry, constLabels pr
 	registry.MustRegister(metrics.jsConsumerAckPendingNum)
 	registry.MustRegister(metrics.jsConsumerPendingNum)
 	registry.MustRegister(metrics.jsConsumerRedeliveredNum)
-	registry.MustRegister(metrics.jsConsumerLastDeliveredSecNum)
-	registry.MustRegister(metrics.jsConsumerLastAckFloorSecNum)
+	registry.MustRegister(metrics.jsConsumerLastDeliveredConsumer)
+	registry.MustRegister(metrics.jsConsumerLastDeliveredStream)
+	registry.MustRegister(metrics.jsConsumerLastAckFloorConsumer)
+	registry.MustRegister(metrics.jsConsumerLastAckFloorStream)
 
 	registry.MustRegister(metrics.jsStreamLimitMaxMsgs)
 	registry.MustRegister(metrics.jsStreamLimitMaxMsgsPer)
@@ -233,6 +247,7 @@ func NewJetStreamConfigListMetrics(registry *prometheus.Registry, constLabels pr
 type jsConfigListListener struct {
 	sync.Mutex
 	cancelLoop context.CancelFunc
+	wg         sync.WaitGroup
 	provider   ConnProvider
 	logger     *logrus.Logger
 	metrics    *JSStreamConfigMetrics
@@ -254,20 +269,32 @@ func NewJetStreamConfigListener(provider ConnProvider, logger *logrus.Logger, me
 }
 
 func (o *jsConfigListListener) gatherData(ctx context.Context, interval time.Duration) {
+	defer o.wg.Done()
 	ticker := time.NewTicker(interval)
 	defer ticker.Stop()
 	o.logger.Infof("starting JetStream config poll loop (interval=%s)", interval)
 	for {
 		select {
 		case <-ticker.C:
+			// Snapshot js under the lock to avoid holding it across blocking NATS I/O.
 			o.Lock()
-			for str := range o.js.Streams() {
+			js := o.js
+			o.Unlock()
+			if js == nil || ctx.Err() != nil {
+				return
+			}
+			for str := range js.Streams() {
+				if ctx.Err() != nil {
+					return
+				}
 				o.StreamHandler(str)
-				for con := range o.js.Consumers(str.Config.Name) {
+				for con := range js.Consumers(str.Config.Name) {
+					if ctx.Err() != nil {
+						return
+					}
 					o.ConsumerHandler(con)
 				}
 			}
-			o.Unlock()
 		case <-ctx.Done():
 			o.logger.Debugln("stopping JetStream config poll loop")
 			return
@@ -297,6 +324,7 @@ func (o *jsConfigListListener) Start(natsCtx *NatsContext) error {
 	ctx, cancelFunc := context.WithCancel(context.Background())
 
 	o.cancelLoop = cancelFunc
+	o.wg.Add(1)
 	go o.gatherData(ctx, o.interval)
 	return nil
 }
@@ -322,14 +350,6 @@ func (o *jsConfigListListener) StreamHandler(streamInfo *nats.StreamInfo) {
 	o.metrics.jsStreamRaftInfo.DeletePartialMatch(prometheus.Labels{
 		"stream_name": streamInfo.Config.Name,
 	})
-	o.metrics.jsStreamRaftInfo.With(
-		prometheus.Labels{
-			"stream_name":   streamInfo.Config.Name,
-			"leader":        streamInfo.Cluster.Leader,
-			"replica_count": strconv.Itoa(len(streamInfo.Cluster.Replicas)),
-		},
-	).Set(1)
-
 	o.metrics.jsStreamRaftPeerInfo.DeletePartialMatch(prometheus.Labels{
 		"stream_name": streamInfo.Config.Name,
 	})
@@ -339,24 +359,33 @@ func (o *jsConfigListListener) StreamHandler(streamInfo *nats.StreamInfo) {
 		},
 	)
 
-	for _, peer := range streamInfo.Cluster.Replicas {
-		o.metrics.jsStreamRaftPeerInfo.With(
+	if streamInfo.Cluster != nil {
+		o.metrics.jsStreamRaftInfo.With(
 			prometheus.Labels{
-				"leader":      streamInfo.Cluster.Leader,
-				"stream_name": streamInfo.Config.Name,
-				"peer_name":   peer.Name,
-				"offline":     convertBoolToString(peer.Offline),
-				"current":     convertBoolToString(peer.Current),
-				"lag":         strconv.FormatUint(peer.Lag, 10),
+				"stream_name":   streamInfo.Config.Name,
+				"leader":        streamInfo.Cluster.Leader,
+				"replica_count": strconv.Itoa(len(streamInfo.Cluster.Replicas)),
 			},
 		).Set(1)
 
-		o.metrics.jsStreamReplicationLag.With(
-			prometheus.Labels{
-				"stream_name": streamInfo.Config.Name,
-				"peer_name":   peer.Name,
-			},
-		).Set(float64(peer.Lag))
+		for _, peer := range streamInfo.Cluster.Replicas {
+			o.metrics.jsStreamRaftPeerInfo.With(
+				prometheus.Labels{
+					"leader":      streamInfo.Cluster.Leader,
+					"stream_name": streamInfo.Config.Name,
+					"peer_name":   peer.Name,
+					"offline":     convertBoolToString(peer.Offline),
+					"current":     convertBoolToString(peer.Current),
+				},
+			).Set(1)
+
+			o.metrics.jsStreamReplicationLag.With(
+				prometheus.Labels{
+					"stream_name": streamInfo.Config.Name,
+					"peer_name":   peer.Name,
+				},
+			).Set(float64(peer.Lag))
+		}
 	}
 
 	o.metrics.jsStreamStateConsumerNum.DeletePartialMatch(prometheus.Labels{
@@ -452,10 +481,12 @@ func (o *jsConfigListListener) ConsumerHandler(consumerInfo *nats.ConsumerInfo) 
 		o.logger.Infof("received empty consumer")
 		return
 	}
-	o.metrics.jsConsumerConfig.DeletePartialMatch(prometheus.Labels{
+	consumerLabels := prometheus.Labels{
 		"stream_name":   consumerInfo.Stream,
 		"consumer_name": consumerInfo.Name,
-	})
+	}
+
+	o.metrics.jsConsumerConfig.DeletePartialMatch(consumerLabels)
 	o.metrics.jsConsumerConfig.With(
 		prometheus.Labels{
 			"stream_name":     consumerInfo.Stream,
@@ -465,24 +496,36 @@ func (o *jsConfigListListener) ConsumerHandler(consumerInfo *nats.ConsumerInfo) 
 			"is_pull":         IsPullBased(consumerInfo),
 		},
 	).Set(1)
-	o.metrics.jsConsumerState.DeletePartialMatch(prometheus.Labels{
-		"stream_name":   consumerInfo.Stream,
-		"consumer_name": consumerInfo.Name,
-	})
-	o.metrics.jsConsumerState.With(
-		prometheus.Labels{
-			"consumer_name":                   consumerInfo.Name,
-			"stream_name":                     consumerInfo.Stream,
-			"last_delivered_message_consumer": strconv.FormatUint(consumerInfo.Delivered.Consumer, 10),
-			"last_delivered_message_stream":   strconv.FormatUint(consumerInfo.Delivered.Stream, 10),
-			"ack_floor_consumer":              strconv.FormatUint(consumerInfo.AckFloor.Consumer, 10),
-			"ack_floor_stream":                strconv.FormatUint(consumerInfo.AckFloor.Stream, 10),
-		}).Set(1)
 
-	o.metrics.jsConsumerRaftInfo.DeletePartialMatch(prometheus.Labels{
-		"stream_name":   consumerInfo.Stream,
-		"consumer_name": consumerInfo.Name,
-	})
+	o.metrics.jsConsumerState.DeletePartialMatch(consumerLabels)
+	o.metrics.jsConsumerState.With(consumerLabels).Set(1)
+
+	o.metrics.jsConsumerWaitingNum.DeletePartialMatch(consumerLabels)
+	o.metrics.jsConsumerPendingNum.DeletePartialMatch(consumerLabels)
+	o.metrics.jsConsumerAckPendingNum.DeletePartialMatch(consumerLabels)
+	o.metrics.jsConsumerRedeliveredNum.DeletePartialMatch(consumerLabels)
+	o.metrics.jsConsumerLastDeliveredConsumer.DeletePartialMatch(consumerLabels)
+	o.metrics.jsConsumerLastDeliveredStream.DeletePartialMatch(consumerLabels)
+	o.metrics.jsConsumerLastAckFloorConsumer.DeletePartialMatch(consumerLabels)
+	o.metrics.jsConsumerLastAckFloorStream.DeletePartialMatch(consumerLabels)
+
+	o.metrics.jsConsumerWaitingNum.With(consumerLabels).Set(float64(consumerInfo.NumWaiting))
+	o.metrics.jsConsumerPendingNum.With(consumerLabels).Set(float64(consumerInfo.NumPending))
+	o.metrics.jsConsumerAckPendingNum.With(consumerLabels).Set(float64(consumerInfo.NumAckPending))
+	o.metrics.jsConsumerRedeliveredNum.With(consumerLabels).Set(float64(consumerInfo.NumRedelivered))
+	o.metrics.jsConsumerLastDeliveredConsumer.With(consumerLabels).Set(float64(consumerInfo.Delivered.Consumer))
+	o.metrics.jsConsumerLastDeliveredStream.With(consumerLabels).Set(float64(consumerInfo.Delivered.Stream))
+	o.metrics.jsConsumerLastAckFloorConsumer.With(consumerLabels).Set(float64(consumerInfo.AckFloor.Consumer))
+	o.metrics.jsConsumerLastAckFloorStream.With(consumerLabels).Set(float64(consumerInfo.AckFloor.Stream))
+
+	o.metrics.jsConsumerRaftInfo.DeletePartialMatch(consumerLabels)
+	o.metrics.jsConsumerRaftPeerInfo.DeletePartialMatch(consumerLabels)
+	o.metrics.jsConsumerReplicationLag.DeletePartialMatch(consumerLabels)
+
+	if consumerInfo.Cluster == nil {
+		// non-clustered (single-server or R1) deployment — no raft/peer data
+		return
+	}
 	o.metrics.jsConsumerRaftInfo.With(
 		prometheus.Labels{
 			"consumer_name": consumerInfo.Name,
@@ -491,17 +534,6 @@ func (o *jsConfigListListener) ConsumerHandler(consumerInfo *nats.ConsumerInfo) 
 			"replica_count": strconv.Itoa(len(consumerInfo.Cluster.Replicas)),
 		},
 	).Set(1)
-
-	o.metrics.jsConsumerRaftPeerInfo.DeletePartialMatch(prometheus.Labels{
-		"stream_name":   consumerInfo.Stream,
-		"consumer_name": consumerInfo.Name,
-	})
-	o.metrics.jsConsumerReplicationLag.DeletePartialMatch(
-		prometheus.Labels{
-			"stream_name":   consumerInfo.Stream,
-			"consumer_name": consumerInfo.Name,
-		},
-	)
 	for _, peer := range consumerInfo.Cluster.Replicas {
 		o.metrics.jsConsumerRaftPeerInfo.With(
 			prometheus.Labels{
@@ -511,10 +543,8 @@ func (o *jsConfigListListener) ConsumerHandler(consumerInfo *nats.ConsumerInfo) 
 				"peer_name":     peer.Name,
 				"offline":       convertBoolToString(peer.Offline),
 				"current":       convertBoolToString(peer.Current),
-				"lag":           strconv.FormatUint(peer.Lag, 10),
 			},
 		).Set(1)
-
 		o.metrics.jsConsumerReplicationLag.With(
 			prometheus.Labels{
 				"stream_name":   consumerInfo.Stream,
@@ -523,69 +553,6 @@ func (o *jsConfigListListener) ConsumerHandler(consumerInfo *nats.ConsumerInfo) 
 			},
 		).Set(float64(peer.Lag))
 	}
-	o.metrics.jsConsumerWaitingNum.DeletePartialMatch(prometheus.Labels{
-		"consumer_name": consumerInfo.Config.Name,
-		"stream_name":   consumerInfo.Stream,
-	})
-	o.metrics.jsConsumerPendingNum.DeletePartialMatch(prometheus.Labels{
-		"consumer_name": consumerInfo.Config.Name,
-		"stream_name":   consumerInfo.Stream,
-	})
-	o.metrics.jsConsumerAckPendingNum.DeletePartialMatch(prometheus.Labels{
-		"consumer_name": consumerInfo.Config.Name,
-		"stream_name":   consumerInfo.Stream,
-	})
-	o.metrics.jsConsumerRedeliveredNum.DeletePartialMatch(prometheus.Labels{
-		"consumer_name": consumerInfo.Config.Name,
-		"stream_name":   consumerInfo.Stream,
-	})
-
-	o.metrics.jsConsumerWaitingNum.With(
-		prometheus.Labels{
-			"consumer_name": consumerInfo.Config.Name,
-			"stream_name":   consumerInfo.Stream,
-		},
-	).Set(float64(consumerInfo.NumWaiting))
-	o.metrics.jsConsumerPendingNum.With(
-		prometheus.Labels{
-			"consumer_name": consumerInfo.Config.Name,
-			"stream_name":   consumerInfo.Stream,
-		},
-	).Set(float64(consumerInfo.NumPending))
-	o.metrics.jsConsumerAckPendingNum.With(
-		prometheus.Labels{
-			"consumer_name": consumerInfo.Config.Name,
-			"stream_name":   consumerInfo.Stream,
-		},
-	).Set(float64(consumerInfo.NumAckPending))
-	o.metrics.jsConsumerRedeliveredNum.With(
-		prometheus.Labels{
-			"consumer_name": consumerInfo.Config.Name,
-			"stream_name":   consumerInfo.Stream,
-		},
-	).Set(float64(consumerInfo.NumRedelivered))
-
-	o.metrics.jsConsumerLastDeliveredSecNum.DeletePartialMatch(prometheus.Labels{
-		"consumer_name": consumerInfo.Config.Name,
-		"stream_name":   consumerInfo.Stream,
-	})
-	o.metrics.jsConsumerLastAckFloorSecNum.DeletePartialMatch(prometheus.Labels{
-		"consumer_name": consumerInfo.Config.Name,
-		"stream_name":   consumerInfo.Stream,
-	})
-
-	o.metrics.jsConsumerLastDeliveredSecNum.With(
-		prometheus.Labels{
-			"consumer_name": consumerInfo.Config.Name,
-			"stream_name":   consumerInfo.Stream,
-		},
-	).Set(float64(consumerInfo.Delivered.Consumer))
-	o.metrics.jsConsumerLastAckFloorSecNum.With(
-		prometheus.Labels{
-			"consumer_name": consumerInfo.Config.Name,
-			"stream_name":   consumerInfo.Stream,
-		},
-	).Set(float64(consumerInfo.AckFloor.Consumer))
 }
 func IsPullBased(info *nats.ConsumerInfo) string {
 	isPull := info.Config.DeliverGroup == "" && info.Config.DeliverSubject == ""
@@ -598,12 +565,22 @@ func IsPullBased(info *nats.ConsumerInfo) string {
 // Stop stops the JetStream config polling loop.
 func (o *jsConfigListListener) Stop() {
 	o.Lock()
-	defer o.Unlock()
 	if o.conn == nil {
 		// already stopped
+		o.Unlock()
 		return
 	}
-	o.cancelLoop()
-	o.conn.Close()
-	o.conn = nil
+	cancel := o.cancelLoop
+	o.Unlock()
+
+	cancel()
+	o.wg.Wait()
+
+	o.Lock()
+	if o.conn != nil {
+		o.conn.Close()
+		o.conn = nil
+		o.js = nil
+	}
+	o.Unlock()
 }

--- a/surveyor/jetstream_configs.go
+++ b/surveyor/jetstream_configs.go
@@ -1,0 +1,609 @@
+// Copyright 2020 The NATS Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package surveyor
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"sync"
+	"time"
+
+	"github.com/nats-io/nats.go"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/sirupsen/logrus"
+)
+
+var (
+	streamConfigLabels           = []string{"discard_policy", "storage_type", "replica_number", "stream_name"}
+	consumerConfigLabels         = []string{"stream_name", "max_pending_ack", "ack_policy", "is_pull", "consumer_name"}
+	streamRaftInfoLabels         = []string{"stream_name", "leader", "replica_count"}
+	streamRaftPeerInfoLabels     = []string{"stream_name", "peer_name", "offline", "current", "leader", "lag"}
+	consumerRaftInfoLabels       = []string{"consumer_name", "leader", "replica_count", "stream_name"}
+	consumerStateLabels          = []string{"consumer_name", "stream_name", "last_delivered_message_consumer", "last_delivered_message_stream", "ack_floor_consumer", "ack_floor_stream"}
+	consumerRaftPeerInfoLabels   = []string{"stream_name", "consumer_name", "peer_name", "offline", "current", "leader", "lag"}
+	streamReplicationLagLabels   = []string{"stream_name", "peer_name"}
+	consumerReplicationLagLabels = []string{"stream_name", "consumer_name", "peer_name"}
+	streamLabel                  = []string{"stream_name"}
+	consumerStreamLabel          = []string{"consumer_name", "stream_name"}
+)
+
+// DefaultJSConfigPollInterval is the polling interval used when the listener is
+// enabled without an explicit interval.
+const DefaultJSConfigPollInterval = 10 * time.Second
+
+type JSStreamConfigMetrics struct {
+	jsStreamConfig           *prometheus.GaugeVec
+	jsStreamRaftInfo         *prometheus.GaugeVec
+	jsStreamRaftPeerInfo     *prometheus.GaugeVec
+	jsStreamReplicationLag   *prometheus.GaugeVec
+	jsStreamStateConsumerNum *prometheus.GaugeVec
+	jsStreamStateDeletedNum  *prometheus.GaugeVec
+	jsStreamStateSubjectNum  *prometheus.GaugeVec
+
+	jsConsumerConfig              *prometheus.GaugeVec
+	jsConsumerState               *prometheus.GaugeVec
+	jsConsumerRaftInfo            *prometheus.GaugeVec
+	jsConsumerRaftPeerInfo        *prometheus.GaugeVec
+	jsConsumerReplicationLag      *prometheus.GaugeVec
+	jsConsumerAckPendingNum       *prometheus.GaugeVec
+	jsConsumerPendingNum          *prometheus.GaugeVec
+	jsConsumerRedeliveredNum      *prometheus.GaugeVec
+	jsConsumerWaitingNum          *prometheus.GaugeVec
+	jsConsumerLastAckFloorSecNum  *prometheus.GaugeVec
+	jsConsumerLastDeliveredSecNum *prometheus.GaugeVec
+
+	jsStreamLimitMaxMsgs      *prometheus.GaugeVec
+	jsStreamLimitMaxMsgsPer   *prometheus.GaugeVec
+	jsStreamLimitMaxBytes     *prometheus.GaugeVec
+	jsStreamLimitMaxAge       *prometheus.GaugeVec
+	jsStreamLimitMaxMsgSize   *prometheus.GaugeVec
+	jsStreamLimitMaxConsumers *prometheus.GaugeVec
+}
+
+func NewJetStreamConfigListMetrics(registry *prometheus.Registry, constLabels prometheus.Labels) *JSStreamConfigMetrics {
+	metrics := &JSStreamConfigMetrics{
+		// API Audit
+		jsStreamConfig: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Name:        prometheus.BuildFQName("nats", "jetstream", "stream_configuration"),
+			Help:        "Configurations for streams",
+			ConstLabels: constLabels,
+		}, streamConfigLabels),
+		jsConsumerConfig: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Name:        prometheus.BuildFQName("nats", "jetstream", "consumer_configuration"),
+			Help:        "Configurations for consumer",
+			ConstLabels: constLabels,
+		}, consumerConfigLabels),
+		jsConsumerState: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Name:        prometheus.BuildFQName("nats", "jetstream", "consumer_state"),
+			Help:        "state of consumer consumer",
+			ConstLabels: constLabels,
+		}, consumerStateLabels),
+		jsStreamRaftInfo: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Name:        prometheus.BuildFQName("nats", "jetstream", "stream_raft_info"),
+			Help:        "raft info for streams",
+			ConstLabels: constLabels,
+		}, streamRaftInfoLabels),
+		jsStreamRaftPeerInfo: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Name:        prometheus.BuildFQName("nats", "jetstream", "stream_raft_peer_info"),
+			Help:        "raft peer info for streams",
+			ConstLabels: constLabels,
+		}, streamRaftPeerInfoLabels),
+		jsStreamStateConsumerNum: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Name:        prometheus.BuildFQName("nats", "jetstream", "stream_consumer_number"),
+			Help:        "consumer number of stream",
+			ConstLabels: constLabels,
+		}, streamLabel),
+		jsStreamStateDeletedNum: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Name:        prometheus.BuildFQName("nats", "jetstream", "stream_deleted_number"),
+			Help:        "deleted number of stream",
+			ConstLabels: constLabels,
+		}, streamLabel),
+		jsStreamStateSubjectNum: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Name:        prometheus.BuildFQName("nats", "jetstream", "stream_subject_number"),
+			Help:        "subject number for streams",
+			ConstLabels: constLabels,
+		}, streamLabel),
+		jsConsumerRaftInfo: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Name:        prometheus.BuildFQName("nats", "jetstream", "consumer_raft_info"),
+			Help:        "raft info for consumer",
+			ConstLabels: constLabels,
+		}, consumerRaftInfoLabels),
+		jsConsumerRaftPeerInfo: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Name:        prometheus.BuildFQName("nats", "jetstream", "consumer_raft_peer_info"),
+			Help:        "raft peer info for consumer",
+			ConstLabels: constLabels,
+		}, consumerRaftPeerInfoLabels),
+		jsStreamReplicationLag: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Name:        prometheus.BuildFQName("nats", "jetstream", "stream_replication_lag"),
+			Help:        "replication lag of stream peers",
+			ConstLabels: constLabels,
+		}, streamReplicationLagLabels),
+		jsConsumerReplicationLag: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Name:        prometheus.BuildFQName("nats", "jetstream", "consumer_replication_lag"),
+			Help:        "replication lag of consumer peers",
+			ConstLabels: constLabels,
+		}, consumerReplicationLagLabels),
+		jsConsumerAckPendingNum: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Name:        prometheus.BuildFQName("nats", "jetstream", "consumer_ack_pending_number"),
+			Help:        "pending ack number of consumer",
+			ConstLabels: constLabels,
+		}, consumerStreamLabel),
+		jsConsumerPendingNum: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Name:        prometheus.BuildFQName("nats", "jetstream", "consumer_pending_number"),
+			Help:        "pending number of consumer",
+			ConstLabels: constLabels,
+		}, consumerStreamLabel),
+		jsConsumerRedeliveredNum: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Name:        prometheus.BuildFQName("nats", "jetstream", "consumer_redelivered_number"),
+			Help:        "redelivered number of consumer",
+			ConstLabels: constLabels,
+		}, consumerStreamLabel),
+		jsConsumerWaitingNum: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Name:        prometheus.BuildFQName("nats", "jetstream", "consumer_waiting_number"),
+			Help:        "waiting number of consumer",
+			ConstLabels: constLabels,
+		}, consumerStreamLabel),
+		jsConsumerLastAckFloorSecNum: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Name:        prometheus.BuildFQName("nats", "jetstream", "consumer_last_ack_floor_number"),
+			Help:        "last ack floor number of consumer",
+			ConstLabels: constLabels,
+		}, consumerStreamLabel),
+		jsConsumerLastDeliveredSecNum: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Name:        prometheus.BuildFQName("nats", "jetstream", "consumer_last_delivered_number"),
+			Help:        "last delivered number of consumer",
+			ConstLabels: constLabels,
+		}, consumerStreamLabel),
+		jsStreamLimitMaxMsgs: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Name:        prometheus.BuildFQName("nats", "jetstream", "stream_limit_max_msgs"),
+			Help:        "Maximum number of messages allowed in the stream (-1 for unlimited)",
+			ConstLabels: constLabels,
+		}, streamLabel),
+		jsStreamLimitMaxMsgsPer: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Name:        prometheus.BuildFQName("nats", "jetstream", "stream_limit_max_msgs_per_subject"),
+			Help:        "Maximum number of messages per subject allowed in the stream (-1 for unlimited)",
+			ConstLabels: constLabels,
+		}, streamLabel),
+		jsStreamLimitMaxBytes: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Name:        prometheus.BuildFQName("nats", "jetstream", "stream_limit_max_bytes"),
+			Help:        "Maximum total bytes allowed in the stream (-1 for unlimited)",
+			ConstLabels: constLabels,
+		}, streamLabel),
+		jsStreamLimitMaxAge: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Name:        prometheus.BuildFQName("nats", "jetstream", "stream_limit_max_age_seconds"),
+			Help:        "Maximum age of messages in seconds (0 for unlimited)",
+			ConstLabels: constLabels,
+		}, streamLabel),
+		jsStreamLimitMaxMsgSize: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Name:        prometheus.BuildFQName("nats", "jetstream", "stream_limit_max_msg_size"),
+			Help:        "Maximum message size in bytes (-1 for unlimited)",
+			ConstLabels: constLabels,
+		}, streamLabel),
+		jsStreamLimitMaxConsumers: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Name:        prometheus.BuildFQName("nats", "jetstream", "stream_limit_max_consumers"),
+			Help:        "Maximum number of consumers allowed (-1 for unlimited)",
+			ConstLabels: constLabels,
+		}, streamLabel),
+	}
+
+	registry.MustRegister(metrics.jsStreamConfig)
+	registry.MustRegister(metrics.jsConsumerConfig)
+	registry.MustRegister(metrics.jsConsumerState)
+	registry.MustRegister(metrics.jsStreamRaftInfo)
+	registry.MustRegister(metrics.jsStreamRaftPeerInfo)
+	registry.MustRegister(metrics.jsStreamStateSubjectNum)
+	registry.MustRegister(metrics.jsStreamStateDeletedNum)
+	registry.MustRegister(metrics.jsStreamStateConsumerNum)
+
+	registry.MustRegister(metrics.jsConsumerRaftInfo)
+	registry.MustRegister(metrics.jsConsumerRaftPeerInfo)
+	registry.MustRegister(metrics.jsStreamReplicationLag)
+	registry.MustRegister(metrics.jsConsumerReplicationLag)
+	registry.MustRegister(metrics.jsConsumerWaitingNum)
+	registry.MustRegister(metrics.jsConsumerAckPendingNum)
+	registry.MustRegister(metrics.jsConsumerPendingNum)
+	registry.MustRegister(metrics.jsConsumerRedeliveredNum)
+	registry.MustRegister(metrics.jsConsumerLastDeliveredSecNum)
+	registry.MustRegister(metrics.jsConsumerLastAckFloorSecNum)
+
+	registry.MustRegister(metrics.jsStreamLimitMaxMsgs)
+	registry.MustRegister(metrics.jsStreamLimitMaxMsgsPer)
+	registry.MustRegister(metrics.jsStreamLimitMaxBytes)
+	registry.MustRegister(metrics.jsStreamLimitMaxAge)
+	registry.MustRegister(metrics.jsStreamLimitMaxMsgSize)
+	registry.MustRegister(metrics.jsStreamLimitMaxConsumers)
+
+	return metrics
+}
+
+// jsConfigListListener polls JetStream stream/consumer configuration and state on an
+// interval and exposes the result as prometheus metrics.
+type jsConfigListListener struct {
+	sync.Mutex
+	cancelLoop context.CancelFunc
+	provider   ConnProvider
+	logger     *logrus.Logger
+	metrics    *JSStreamConfigMetrics
+	interval   time.Duration
+	conn       Conn
+	js         nats.JetStreamContext
+}
+
+func NewJetStreamConfigListener(provider ConnProvider, logger *logrus.Logger, metrics *JSStreamConfigMetrics, interval time.Duration) *jsConfigListListener {
+	if interval <= 0 {
+		interval = DefaultJSConfigPollInterval
+	}
+	return &jsConfigListListener{
+		provider: provider,
+		logger:   logger,
+		metrics:  metrics,
+		interval: interval,
+	}
+}
+
+func (o *jsConfigListListener) gatherData(ctx context.Context, interval time.Duration) {
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	o.logger.Infof("starting JetStream config poll loop (interval=%s)", interval)
+	for {
+		select {
+		case <-ticker.C:
+			o.Lock()
+			for str := range o.js.Streams() {
+				o.StreamHandler(str)
+				for con := range o.js.Consumers(str.Config.Name) {
+					o.ConsumerHandler(con)
+				}
+			}
+			o.Unlock()
+		case <-ctx.Done():
+			o.logger.Debugln("stopping JetStream config poll loop")
+			return
+		}
+	}
+}
+
+func (o *jsConfigListListener) Start(natsCtx *NatsContext) error {
+	o.Lock()
+	defer o.Unlock()
+	if o.conn != nil {
+		// already started
+		return nil
+	}
+	conn, err := o.provider.Get(natsCtx)
+	if err != nil {
+		return fmt.Errorf("nats connection failed: %v", err)
+	}
+	o.conn = conn
+	js, err := conn.Conn().JetStream()
+	if err != nil {
+		o.conn.Close()
+		o.conn = nil
+		return fmt.Errorf("failed to create jetstream context: %v", err)
+	}
+	o.js = js
+	ctx, cancelFunc := context.WithCancel(context.Background())
+
+	o.cancelLoop = cancelFunc
+	go o.gatherData(ctx, o.interval)
+	return nil
+}
+
+func (o *jsConfigListListener) StreamHandler(streamInfo *nats.StreamInfo) {
+	if streamInfo == nil {
+		o.logger.Infof("received empty stream")
+		return
+	}
+	o.metrics.jsStreamConfig.DeletePartialMatch(prometheus.Labels{
+		"stream_name": streamInfo.Config.Name,
+	})
+
+	o.metrics.jsStreamConfig.With(
+		prometheus.Labels{
+			"discard_policy": streamInfo.Config.Discard.String(),
+			"storage_type":   streamInfo.Config.Storage.String(),
+			"replica_number": strconv.Itoa(streamInfo.Config.Replicas),
+			"stream_name":    streamInfo.Config.Name,
+		},
+	).Set(1)
+
+	o.metrics.jsStreamRaftInfo.DeletePartialMatch(prometheus.Labels{
+		"stream_name": streamInfo.Config.Name,
+	})
+	o.metrics.jsStreamRaftInfo.With(
+		prometheus.Labels{
+			"stream_name":   streamInfo.Config.Name,
+			"leader":        streamInfo.Cluster.Leader,
+			"replica_count": strconv.Itoa(len(streamInfo.Cluster.Replicas)),
+		},
+	).Set(1)
+
+	o.metrics.jsStreamRaftPeerInfo.DeletePartialMatch(prometheus.Labels{
+		"stream_name": streamInfo.Config.Name,
+	})
+	o.metrics.jsStreamReplicationLag.DeletePartialMatch(
+		prometheus.Labels{
+			"stream_name": streamInfo.Config.Name,
+		},
+	)
+
+	for _, peer := range streamInfo.Cluster.Replicas {
+		o.metrics.jsStreamRaftPeerInfo.With(
+			prometheus.Labels{
+				"leader":      streamInfo.Cluster.Leader,
+				"stream_name": streamInfo.Config.Name,
+				"peer_name":   peer.Name,
+				"offline":     convertBoolToString(peer.Offline),
+				"current":     convertBoolToString(peer.Current),
+				"lag":         strconv.FormatUint(peer.Lag, 10),
+			},
+		).Set(1)
+
+		o.metrics.jsStreamReplicationLag.With(
+			prometheus.Labels{
+				"stream_name": streamInfo.Config.Name,
+				"peer_name":   peer.Name,
+			},
+		).Set(float64(peer.Lag))
+	}
+
+	o.metrics.jsStreamStateConsumerNum.DeletePartialMatch(prometheus.Labels{
+		"stream_name": streamInfo.Config.Name,
+	})
+	o.metrics.jsStreamStateSubjectNum.DeletePartialMatch(prometheus.Labels{
+		"stream_name": streamInfo.Config.Name,
+	})
+	o.metrics.jsStreamStateDeletedNum.DeletePartialMatch(prometheus.Labels{
+		"stream_name": streamInfo.Config.Name,
+	})
+
+	o.metrics.jsStreamStateSubjectNum.With(
+		prometheus.Labels{
+			"stream_name": streamInfo.Config.Name,
+		},
+	).Set(float64(streamInfo.State.NumSubjects))
+	o.metrics.jsStreamStateDeletedNum.With(
+		prometheus.Labels{
+			"stream_name": streamInfo.Config.Name,
+		},
+	).Set(float64(streamInfo.State.NumDeleted))
+	o.metrics.jsStreamStateConsumerNum.With(
+		prometheus.Labels{
+			"stream_name": streamInfo.Config.Name,
+		},
+	).Set(float64(streamInfo.State.Consumers))
+
+	// Stream Limits
+	o.metrics.jsStreamLimitMaxMsgs.DeletePartialMatch(prometheus.Labels{
+		"stream_name": streamInfo.Config.Name,
+	})
+	o.metrics.jsStreamLimitMaxMsgsPer.DeletePartialMatch(prometheus.Labels{
+		"stream_name": streamInfo.Config.Name,
+	})
+	o.metrics.jsStreamLimitMaxBytes.DeletePartialMatch(prometheus.Labels{
+		"stream_name": streamInfo.Config.Name,
+	})
+	o.metrics.jsStreamLimitMaxAge.DeletePartialMatch(prometheus.Labels{
+		"stream_name": streamInfo.Config.Name,
+	})
+	o.metrics.jsStreamLimitMaxMsgSize.DeletePartialMatch(prometheus.Labels{
+		"stream_name": streamInfo.Config.Name,
+	})
+	o.metrics.jsStreamLimitMaxConsumers.DeletePartialMatch(prometheus.Labels{
+		"stream_name": streamInfo.Config.Name,
+	})
+
+	o.metrics.jsStreamLimitMaxMsgs.With(
+		prometheus.Labels{
+			"stream_name": streamInfo.Config.Name,
+		},
+	).Set(float64(streamInfo.Config.MaxMsgs))
+
+	o.metrics.jsStreamLimitMaxMsgsPer.With(
+		prometheus.Labels{
+			"stream_name": streamInfo.Config.Name,
+		},
+	).Set(float64(streamInfo.Config.MaxMsgsPerSubject))
+
+	o.metrics.jsStreamLimitMaxBytes.With(
+		prometheus.Labels{
+			"stream_name": streamInfo.Config.Name,
+		},
+	).Set(float64(streamInfo.Config.MaxBytes))
+
+	o.metrics.jsStreamLimitMaxAge.With(
+		prometheus.Labels{
+			"stream_name": streamInfo.Config.Name,
+		},
+	).Set(streamInfo.Config.MaxAge.Seconds())
+
+	o.metrics.jsStreamLimitMaxMsgSize.With(
+		prometheus.Labels{
+			"stream_name": streamInfo.Config.Name,
+		},
+	).Set(float64(streamInfo.Config.MaxMsgSize))
+
+	o.metrics.jsStreamLimitMaxConsumers.With(
+		prometheus.Labels{
+			"stream_name": streamInfo.Config.Name,
+		},
+	).Set(float64(streamInfo.Config.MaxConsumers))
+}
+func convertBoolToString(value bool) string {
+	if value {
+		return "true"
+	}
+	return "false"
+}
+func (o *jsConfigListListener) ConsumerHandler(consumerInfo *nats.ConsumerInfo) {
+	if consumerInfo == nil {
+		o.logger.Infof("received empty consumer")
+		return
+	}
+	o.metrics.jsConsumerConfig.DeletePartialMatch(prometheus.Labels{
+		"stream_name":   consumerInfo.Stream,
+		"consumer_name": consumerInfo.Name,
+	})
+	o.metrics.jsConsumerConfig.With(
+		prometheus.Labels{
+			"stream_name":     consumerInfo.Stream,
+			"consumer_name":   consumerInfo.Name,
+			"max_pending_ack": strconv.Itoa(consumerInfo.Config.MaxAckPending),
+			"ack_policy":      consumerInfo.Config.AckPolicy.String(),
+			"is_pull":         IsPullBased(consumerInfo),
+		},
+	).Set(1)
+	o.metrics.jsConsumerState.DeletePartialMatch(prometheus.Labels{
+		"stream_name":   consumerInfo.Stream,
+		"consumer_name": consumerInfo.Name,
+	})
+	o.metrics.jsConsumerState.With(
+		prometheus.Labels{
+			"consumer_name":                   consumerInfo.Name,
+			"stream_name":                     consumerInfo.Stream,
+			"last_delivered_message_consumer": strconv.FormatUint(consumerInfo.Delivered.Consumer, 10),
+			"last_delivered_message_stream":   strconv.FormatUint(consumerInfo.Delivered.Stream, 10),
+			"ack_floor_consumer":              strconv.FormatUint(consumerInfo.AckFloor.Consumer, 10),
+			"ack_floor_stream":                strconv.FormatUint(consumerInfo.AckFloor.Stream, 10),
+		}).Set(1)
+
+	o.metrics.jsConsumerRaftInfo.DeletePartialMatch(prometheus.Labels{
+		"stream_name":   consumerInfo.Stream,
+		"consumer_name": consumerInfo.Name,
+	})
+	o.metrics.jsConsumerRaftInfo.With(
+		prometheus.Labels{
+			"consumer_name": consumerInfo.Name,
+			"stream_name":   consumerInfo.Stream,
+			"leader":        consumerInfo.Cluster.Leader,
+			"replica_count": strconv.Itoa(len(consumerInfo.Cluster.Replicas)),
+		},
+	).Set(1)
+
+	o.metrics.jsConsumerRaftPeerInfo.DeletePartialMatch(prometheus.Labels{
+		"stream_name":   consumerInfo.Stream,
+		"consumer_name": consumerInfo.Name,
+	})
+	o.metrics.jsConsumerReplicationLag.DeletePartialMatch(
+		prometheus.Labels{
+			"stream_name":   consumerInfo.Stream,
+			"consumer_name": consumerInfo.Name,
+		},
+	)
+	for _, peer := range consumerInfo.Cluster.Replicas {
+		o.metrics.jsConsumerRaftPeerInfo.With(
+			prometheus.Labels{
+				"leader":        consumerInfo.Cluster.Leader,
+				"stream_name":   consumerInfo.Stream,
+				"consumer_name": consumerInfo.Name,
+				"peer_name":     peer.Name,
+				"offline":       convertBoolToString(peer.Offline),
+				"current":       convertBoolToString(peer.Current),
+				"lag":           strconv.FormatUint(peer.Lag, 10),
+			},
+		).Set(1)
+
+		o.metrics.jsConsumerReplicationLag.With(
+			prometheus.Labels{
+				"stream_name":   consumerInfo.Stream,
+				"consumer_name": consumerInfo.Name,
+				"peer_name":     peer.Name,
+			},
+		).Set(float64(peer.Lag))
+	}
+	o.metrics.jsConsumerWaitingNum.DeletePartialMatch(prometheus.Labels{
+		"consumer_name": consumerInfo.Config.Name,
+		"stream_name":   consumerInfo.Stream,
+	})
+	o.metrics.jsConsumerPendingNum.DeletePartialMatch(prometheus.Labels{
+		"consumer_name": consumerInfo.Config.Name,
+		"stream_name":   consumerInfo.Stream,
+	})
+	o.metrics.jsConsumerAckPendingNum.DeletePartialMatch(prometheus.Labels{
+		"consumer_name": consumerInfo.Config.Name,
+		"stream_name":   consumerInfo.Stream,
+	})
+	o.metrics.jsConsumerRedeliveredNum.DeletePartialMatch(prometheus.Labels{
+		"consumer_name": consumerInfo.Config.Name,
+		"stream_name":   consumerInfo.Stream,
+	})
+
+	o.metrics.jsConsumerWaitingNum.With(
+		prometheus.Labels{
+			"consumer_name": consumerInfo.Config.Name,
+			"stream_name":   consumerInfo.Stream,
+		},
+	).Set(float64(consumerInfo.NumWaiting))
+	o.metrics.jsConsumerPendingNum.With(
+		prometheus.Labels{
+			"consumer_name": consumerInfo.Config.Name,
+			"stream_name":   consumerInfo.Stream,
+		},
+	).Set(float64(consumerInfo.NumPending))
+	o.metrics.jsConsumerAckPendingNum.With(
+		prometheus.Labels{
+			"consumer_name": consumerInfo.Config.Name,
+			"stream_name":   consumerInfo.Stream,
+		},
+	).Set(float64(consumerInfo.NumAckPending))
+	o.metrics.jsConsumerRedeliveredNum.With(
+		prometheus.Labels{
+			"consumer_name": consumerInfo.Config.Name,
+			"stream_name":   consumerInfo.Stream,
+		},
+	).Set(float64(consumerInfo.NumRedelivered))
+
+	o.metrics.jsConsumerLastDeliveredSecNum.DeletePartialMatch(prometheus.Labels{
+		"consumer_name": consumerInfo.Config.Name,
+		"stream_name":   consumerInfo.Stream,
+	})
+	o.metrics.jsConsumerLastAckFloorSecNum.DeletePartialMatch(prometheus.Labels{
+		"consumer_name": consumerInfo.Config.Name,
+		"stream_name":   consumerInfo.Stream,
+	})
+
+	o.metrics.jsConsumerLastDeliveredSecNum.With(
+		prometheus.Labels{
+			"consumer_name": consumerInfo.Config.Name,
+			"stream_name":   consumerInfo.Stream,
+		},
+	).Set(float64(consumerInfo.Delivered.Consumer))
+	o.metrics.jsConsumerLastAckFloorSecNum.With(
+		prometheus.Labels{
+			"consumer_name": consumerInfo.Config.Name,
+			"stream_name":   consumerInfo.Stream,
+		},
+	).Set(float64(consumerInfo.AckFloor.Consumer))
+}
+func IsPullBased(info *nats.ConsumerInfo) string {
+	isPull := info.Config.DeliverGroup == "" && info.Config.DeliverSubject == ""
+	if isPull {
+		return "true"
+	}
+	return "false"
+}
+
+// Stop stops the JetStream config polling loop.
+func (o *jsConfigListListener) Stop() {
+	o.Lock()
+	defer o.Unlock()
+	if o.conn == nil {
+		// already stopped
+		return
+	}
+	o.cancelLoop()
+	o.conn.Close()
+	o.conn = nil
+}

--- a/surveyor/jetstream_configs_test.go
+++ b/surveyor/jetstream_configs_test.go
@@ -1,0 +1,166 @@
+// Copyright 2020 The NATS Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package surveyor
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	st "github.com/nats-io/nats-surveyor/test"
+	"github.com/nats-io/nats.go"
+	"github.com/nats-io/nats.go/jetstream"
+	"github.com/prometheus/client_golang/prometheus"
+	ptu "github.com/prometheus/client_golang/prometheus/testutil"
+)
+
+func TestJetStreamConfig_IntervalValidation(t *testing.T) {
+	registry := prometheus.NewRegistry()
+	metrics := NewJetStreamConfigMetrics(registry, nil)
+	opt := GetDefaultOptions()
+	cp := newSurveyorConnPool(opt, registry)
+
+	for _, interval := range []time.Duration{-time.Second, 0, 999 * time.Millisecond} {
+		if _, err := newJetStreamConfigListener(cp, opt.Logger, metrics, interval); err == nil {
+			t.Fatalf("expected interval %s to be rejected", interval)
+		}
+	}
+
+	if _, err := newJetStreamConfigListener(cp, opt.Logger, metrics, MinJSConfigPollInterval); err != nil {
+		t.Fatalf("expected interval %s to be accepted: %s", MinJSConfigPollInterval, err)
+	}
+}
+
+func TestJetStreamConfig_Poll(t *testing.T) {
+	srv := st.NewJetStreamServer(t)
+	defer srv.Shutdown()
+
+	nc, err := nats.Connect(srv.ClientURL())
+	if err != nil {
+		t.Fatalf("could not connect to nats: %s", err)
+	}
+	defer nc.Close()
+
+	js, err := jetstream.New(nc)
+	if err != nil {
+		t.Fatalf("could not create jetstream context: %s", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	stream, err := js.CreateStream(ctx, jetstream.StreamConfig{
+		Name:     "SURVEYED",
+		Subjects: []string{"surveyed.>"},
+		MaxMsgs:  100,
+	})
+	if err != nil {
+		t.Fatalf("could not create stream: %s", err)
+	}
+	if _, err := stream.CreateConsumer(ctx, jetstream.ConsumerConfig{Durable: "PULLER"}); err != nil {
+		t.Fatalf("could not create consumer: %s", err)
+	}
+
+	opt := GetDefaultOptions()
+	opt.URLs = srv.ClientURL()
+	registry := prometheus.NewRegistry()
+	metrics := NewJetStreamConfigMetrics(registry, nil)
+	cp := newSurveyorConnPool(opt, registry)
+
+	listener, err := newJetStreamConfigListener(cp, opt.Logger, metrics, MinJSConfigPollInterval)
+	if err != nil {
+		t.Fatalf("could not create listener: %s", err)
+	}
+	if err := listener.Start(&NatsContext{}); err != nil {
+		t.Fatalf("could not start listener: %s", err)
+	}
+	defer listener.Stop()
+
+	waitFor(t, func() bool { return ptu.CollectAndCount(metrics.jsStreamConfig) == 1 }, "stream configuration metric")
+
+	if got := ptu.ToFloat64(metrics.jsStreamLimitMaxMsgs.WithLabelValues("SURVEYED")); got != 100 {
+		t.Fatalf("unexpected stream max msgs limit: got %v, expected 100", got)
+	}
+
+	waitFor(t, func() bool { return ptu.CollectAndCount(metrics.jsConsumerConfig) == 1 }, "consumer configuration metric")
+
+	if got := ptu.ToFloat64(metrics.jsConsumerConfig.WithLabelValues("SURVEYED", "PULLER", "AckExplicit", "true")); got != 1 {
+		t.Fatalf("unexpected consumer configuration metric: got %v, expected 1", got)
+	}
+
+	// The server is not clustered, so there is no Raft group to report on.
+	if got := ptu.CollectAndCount(metrics.jsStreamPeerLeader); got != 0 {
+		t.Fatalf("unexpected stream peer series on a non-clustered server: got %d", got)
+	}
+
+	// Deleting the stream has to take its series with it, including those of
+	// its consumers.
+	if err := js.DeleteStream(ctx, "SURVEYED"); err != nil {
+		t.Fatalf("could not delete stream: %s", err)
+	}
+	waitFor(t, func() bool {
+		return ptu.CollectAndCount(metrics.jsStreamConfig) == 0 &&
+			ptu.CollectAndCount(metrics.jsStreamLimitMaxMsgs) == 0 &&
+			ptu.CollectAndCount(metrics.jsConsumerConfig) == 0
+	}, "series of the deleted stream to be removed")
+}
+
+func TestJetStreamConfig_RaftPeers(t *testing.T) {
+	if peers := raftPeers(nil); peers != nil {
+		t.Fatalf("expected no peers without cluster info, got %v", peers)
+	}
+
+	peers := raftPeers(&jetstream.ClusterInfo{
+		Leader: "s1",
+		Replicas: []*jetstream.PeerInfo{
+			{Name: "s2", Current: true},
+			{Name: "s3", Offline: true, Lag: 42},
+		},
+	})
+
+	expected := []raftPeer{
+		{name: "s1", leader: true, current: true},
+		{name: "s2", current: true},
+		{name: "s3", offline: true, lag: 42},
+	}
+	if len(peers) != len(expected) {
+		t.Fatalf("unexpected peers: got %v, expected %v", peers, expected)
+	}
+	for i, peer := range peers {
+		if peer != expected[i] {
+			t.Fatalf("unexpected peer at %d: got %v, expected %v", i, peer, expected[i])
+		}
+	}
+}
+
+func TestJetStreamConfig_IsPullBased(t *testing.T) {
+	if !isPullBased(jetstream.ConsumerConfig{}) {
+		t.Fatal("expected a consumer without a delivery subject to be pull based")
+	}
+	if isPullBased(jetstream.ConsumerConfig{DeliverSubject: "deliver.here"}) {
+		t.Fatal("expected a consumer with a delivery subject to be push based")
+	}
+}
+
+func waitFor(t *testing.T, condition func() bool, what string) {
+	t.Helper()
+	deadline := time.Now().Add(15 * time.Second)
+	for time.Now().Before(deadline) {
+		if condition() {
+			return
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for %s", what)
+}

--- a/surveyor/surveyor.go
+++ b/surveyor/surveyor.go
@@ -123,21 +123,21 @@ func GetDefaultOptions() *Options {
 // A Surveyor instance
 type Surveyor struct {
 	sync.Mutex
-	httpServer           *http.Server
-	jsAdvisoryManager    *JSAdvisoryManager
-	jsAdvisoryFSWatcher  *jsAdvisoryFSWatcher
-	jsConfigListListener *jsConfigListListener
-	listener             net.Listener
-	logger               *logrus.Logger
-	opts                 Options
-	promRegistry         *prometheus.Registry
-	statzC               *StatzCollector
-	serviceObsManager    *ServiceObsManager
-	serviceObsFSWatcher  *serviceObsFSWatcher
-	connProvider         ConnProvider
-	conn                 Conn
-	openConnections      []Conn
-	running              bool
+	httpServer          *http.Server
+	jsAdvisoryManager   *JSAdvisoryManager
+	jsAdvisoryFSWatcher *jsAdvisoryFSWatcher
+	jsConfigListener    *jsConfigListener
+	listener            net.Listener
+	logger              *logrus.Logger
+	opts                Options
+	promRegistry        *prometheus.Registry
+	statzC              *StatzCollector
+	serviceObsManager   *ServiceObsManager
+	serviceObsFSWatcher *serviceObsFSWatcher
+	connProvider        ConnProvider
+	conn                Conn
+	openConnections     []Conn
+	running             bool
 }
 
 // NewSurveyor creates a surveyor
@@ -159,23 +159,27 @@ func NewSurveyor(opts *Options) (*Surveyor, error) {
 	jsAdvisoryManager := NewJetStreamAdvisoryManager(opts.Provider, opts.Logger, jsAdvisoryMetrics)
 	jsFsWatcher := newJetStreamAdvisoryFSWatcher(opts.Logger, jsAdvisoryManager)
 
-	var jsConfigListener *jsConfigListListener
+	var configListener *jsConfigListener
 	if opts.JSConfigPollInterval > 0 {
-		jsConfigListMetrics := NewJetStreamConfigListMetrics(promRegistry, opts.ConstLabels)
-		jsConfigListener = NewJetStreamConfigListener(opts.Provider, opts.Logger, jsConfigListMetrics, opts.JSConfigPollInterval)
+		jsConfigMetrics := NewJetStreamConfigMetrics(promRegistry, opts.ConstLabels)
+		listener, err := newJetStreamConfigListener(opts.Provider, opts.Logger, jsConfigMetrics, opts.JSConfigPollInterval)
+		if err != nil {
+			return nil, err
+		}
+		configListener = listener
 	}
 
 	return &Surveyor{
-		connProvider:         opts.Provider,
-		openConnections:      make([]Conn, 0),
-		jsAdvisoryManager:    jsAdvisoryManager,
-		jsAdvisoryFSWatcher:  jsFsWatcher,
-		jsConfigListListener: jsConfigListener,
-		logger:               opts.Logger,
-		opts:                 *opts,
-		promRegistry:         promRegistry,
-		serviceObsManager:    serviceObsManager,
-		serviceObsFSWatcher:  serviceFsWatcher,
+		connProvider:        opts.Provider,
+		openConnections:     make([]Conn, 0),
+		jsAdvisoryManager:   jsAdvisoryManager,
+		jsAdvisoryFSWatcher: jsFsWatcher,
+		jsConfigListener:    configListener,
+		logger:              opts.Logger,
+		opts:                *opts,
+		promRegistry:        promRegistry,
+		serviceObsManager:   serviceObsManager,
+		serviceObsFSWatcher: serviceFsWatcher,
 	}, nil
 }
 
@@ -184,6 +188,9 @@ func (s *Surveyor) MetricInfos() []MetricInfo {
 	infos = append(infos, s.statzC.MetricInfos()...)
 	infos = append(infos, s.serviceObsManager.metrics.MetricInfos()...)
 	infos = append(infos, s.jsAdvisoryManager.metrics.MetricInfos()...)
+	if s.jsConfigListener != nil {
+		infos = append(infos, s.jsConfigListener.metrics.MetricInfos()...)
+	}
 	return infos
 }
 
@@ -461,9 +468,9 @@ func (s *Surveyor) startJetStreamAdvisories() {
 	}
 }
 
-func (s *Surveyor) startJetStreamConfigList() {
-	if s.jsConfigListListener == nil {
-		return
+func (s *Surveyor) startJetStreamConfigListener() error {
+	if s.jsConfigListener == nil {
+		return nil
 	}
 	natsCtx := &NatsContext{
 		Credentials: s.opts.Credentials,
@@ -474,9 +481,10 @@ func (s *Surveyor) startJetStreamConfigList() {
 		Password:    s.opts.NATSPassword,
 		TokenFile:   s.opts.TokenFile,
 	}
-	if err := s.jsConfigListListener.Start(natsCtx); err != nil {
-		s.logger.Errorf("failed to start JetStream config poll listener: %s", err)
+	if err := s.jsConfigListener.Start(natsCtx); err != nil {
+		return fmt.Errorf("could not start JetStream config poll listener: %w", err)
 	}
+	return nil
 }
 
 func (s *Surveyor) startServiceObservations() {
@@ -563,7 +571,9 @@ func (s *Surveyor) Start() error {
 
 	s.startServiceObservations()
 	s.startJetStreamAdvisories()
-	s.startJetStreamConfigList()
+	if err := s.startJetStreamConfigListener(); err != nil {
+		return err
+	}
 
 	if !s.opts.DisableHTTPServer && s.listener == nil && s.httpServer == nil {
 		if err := s.startHTTP(); err != nil {
@@ -607,8 +617,8 @@ func (s *Surveyor) Stop() {
 	s.jsAdvisoryFSWatcher.stop()
 	s.jsAdvisoryManager.Stop()
 
-	if s.jsConfigListListener != nil {
-		s.jsConfigListListener.Stop()
+	if s.jsConfigListener != nil {
+		s.jsConfigListener.Stop()
 	}
 
 	s.connProvider.Close(true)

--- a/surveyor/surveyor.go
+++ b/surveyor/surveyor.go
@@ -90,6 +90,7 @@ type Options struct {
 	JszLimit             int
 	JszLeadersOnly       bool
 	JszFilters           []JszFilter
+	JSConfigPollInterval time.Duration
 	SysReqPrefix         string
 	Logger               *logrus.Logger    // not exposed by CLI
 	Provider             ConnProvider      // not exposed by CLI
@@ -122,20 +123,21 @@ func GetDefaultOptions() *Options {
 // A Surveyor instance
 type Surveyor struct {
 	sync.Mutex
-	httpServer          *http.Server
-	jsAdvisoryManager   *JSAdvisoryManager
-	jsAdvisoryFSWatcher *jsAdvisoryFSWatcher
-	listener            net.Listener
-	logger              *logrus.Logger
-	opts                Options
-	promRegistry        *prometheus.Registry
-	statzC              *StatzCollector
-	serviceObsManager   *ServiceObsManager
-	serviceObsFSWatcher *serviceObsFSWatcher
-	connProvider        ConnProvider
-	conn                Conn
-	openConnections     []Conn
-	running             bool
+	httpServer           *http.Server
+	jsAdvisoryManager    *JSAdvisoryManager
+	jsAdvisoryFSWatcher  *jsAdvisoryFSWatcher
+	jsConfigListListener *jsConfigListListener
+	listener             net.Listener
+	logger               *logrus.Logger
+	opts                 Options
+	promRegistry         *prometheus.Registry
+	statzC               *StatzCollector
+	serviceObsManager    *ServiceObsManager
+	serviceObsFSWatcher  *serviceObsFSWatcher
+	connProvider         ConnProvider
+	conn                 Conn
+	openConnections      []Conn
+	running              bool
 }
 
 // NewSurveyor creates a surveyor
@@ -157,16 +159,23 @@ func NewSurveyor(opts *Options) (*Surveyor, error) {
 	jsAdvisoryManager := NewJetStreamAdvisoryManager(opts.Provider, opts.Logger, jsAdvisoryMetrics)
 	jsFsWatcher := newJetStreamAdvisoryFSWatcher(opts.Logger, jsAdvisoryManager)
 
+	var jsConfigListener *jsConfigListListener
+	if opts.JSConfigPollInterval > 0 {
+		jsConfigListMetrics := NewJetStreamConfigListMetrics(promRegistry, opts.ConstLabels)
+		jsConfigListener = NewJetStreamConfigListener(opts.Provider, opts.Logger, jsConfigListMetrics, opts.JSConfigPollInterval)
+	}
+
 	return &Surveyor{
-		connProvider:        opts.Provider,
-		openConnections:     make([]Conn, 0),
-		jsAdvisoryManager:   jsAdvisoryManager,
-		jsAdvisoryFSWatcher: jsFsWatcher,
-		logger:              opts.Logger,
-		opts:                *opts,
-		promRegistry:        promRegistry,
-		serviceObsManager:   serviceObsManager,
-		serviceObsFSWatcher: serviceFsWatcher,
+		connProvider:         opts.Provider,
+		openConnections:      make([]Conn, 0),
+		jsAdvisoryManager:    jsAdvisoryManager,
+		jsAdvisoryFSWatcher:  jsFsWatcher,
+		jsConfigListListener: jsConfigListener,
+		logger:               opts.Logger,
+		opts:                 *opts,
+		promRegistry:         promRegistry,
+		serviceObsManager:    serviceObsManager,
+		serviceObsFSWatcher:  serviceFsWatcher,
 	}, nil
 }
 
@@ -452,6 +461,24 @@ func (s *Surveyor) startJetStreamAdvisories() {
 	}
 }
 
+func (s *Surveyor) startJetStreamConfigList() {
+	if s.jsConfigListListener == nil {
+		return
+	}
+	natsCtx := &NatsContext{
+		Credentials: s.opts.Credentials,
+		Nkey:        s.opts.Nkey,
+		JWT:         s.opts.JWT,
+		Seed:        s.opts.Seed,
+		Username:    s.opts.NATSUser,
+		Password:    s.opts.NATSPassword,
+		TokenFile:   s.opts.TokenFile,
+	}
+	if err := s.jsConfigListListener.Start(natsCtx); err != nil {
+		s.logger.Errorf("failed to start JetStream config poll listener: %s", err)
+	}
+}
+
 func (s *Surveyor) startServiceObservations() {
 	if s.serviceObsManager.IsRunning() {
 		return
@@ -536,6 +563,7 @@ func (s *Surveyor) Start() error {
 
 	s.startServiceObservations()
 	s.startJetStreamAdvisories()
+	s.startJetStreamConfigList()
 
 	if !s.opts.DisableHTTPServer && s.listener == nil && s.httpServer == nil {
 		if err := s.startHTTP(); err != nil {
@@ -578,6 +606,10 @@ func (s *Surveyor) Stop() {
 
 	s.jsAdvisoryFSWatcher.stop()
 	s.jsAdvisoryManager.Stop()
+
+	if s.jsConfigListListener != nil {
+		s.jsConfigListListener.Stop()
+	}
 
 	s.connProvider.Close(true)
 	s.running = false


### PR DESCRIPTION
## Summary

Add an opt-in polling listener that queries the JetStream API on an interval and exports per-stream and per-consumer **configuration**, **limits** and **Raft peer health** as Prometheus gauges. It is fully opt-in through a new flag and adds no overhead to existing deployments.

This deliberately complements, rather than overlaps, the jsz metrics `StatzCollector` already exports. Everything jsz covers — message counts, sequences, pending/waiting/ack-pending — is left to jsz; this listener only adds what jsz has no answer for.

## Why this is useful

Two gaps the existing collectors do not cover:

1. **Per-peer replication lag and peer health.** `StatzCollector` exports `Active`/`Current`/`Offline` for meta replicas, but not how far behind in the log each peer of a *stream or consumer* Raft group is. Per-peer lag is the first signal that a follower is falling behind enough to need intervention.
2. **Limit saturation.** Streams hit their `MaxBytes` / `MaxMsgs` / `MaxMsgsPer` limits silently. Exposing the configured limit as a gauge lets the existing jsz numbers be alerted against it, e.g. `nats_stream_total_messages / nats_jetstream_stream_limit_max_msgs > 0.9`.

## Metrics added

Stream-scoped, labelled `stream` (and `peer_name` where applicable):

```
nats_jetstream_stream_configuration          # 1, config in labels: discard_policy, storage_type, replica_number
nats_jetstream_stream_deleted_count
nats_jetstream_stream_limit_max_msgs
nats_jetstream_stream_limit_max_msgs_per_subject
nats_jetstream_stream_limit_max_bytes
nats_jetstream_stream_limit_max_age_seconds
nats_jetstream_stream_limit_max_msg_size
nats_jetstream_stream_limit_max_consumers
nats_jetstream_stream_peer_leader            # 0/1
nats_jetstream_stream_peer_current           # 0/1
nats_jetstream_stream_peer_offline           # 0/1
nats_jetstream_stream_replication_lag
```

Consumer-scoped, labelled `stream` and `consumer_name` (and `peer_name` where applicable):

```
nats_jetstream_consumer_configuration        # 1, config in labels: ack_policy, is_pull
nats_jetstream_consumer_limit_max_ack_pending
nats_jetstream_consumer_peer_leader          # 0/1
nats_jetstream_consumer_peer_current         # 0/1
nats_jetstream_consumer_peer_offline         # 0/1
nats_jetstream_consumer_replication_lag
```

Plus `nats_jetstream_config_poll_errors{operation}`, a counter of failed JetStream API requests, so a poll that stops working is visible rather than silent.

## Design

- Follows the `JSAdvisoryManager` / `ServiceObsManager` pattern: takes the existing `ConnProvider`, builds a `NatsContext` from the main options, pulls its own `Conn` at `Start`, releases it on `Stop`.
- Uses the `nats.go/jetstream` package (`ListStreams(ctx)` / `ListConsumers(ctx)`), not the legacy `JetStreamContext`, so the poll context drives the listing instead of the legacy channel API's implicit 5s deadline. Lister errors are logged and counted.
- `AccountInfo` is probed at `Start`. Creating a JetStream context does no server round-trip, so without the probe a credential that cannot reach the JetStream API would produce zero metrics and zero log lines forever. A failed probe now fails `Surveyor.Start()`.
- Single goroutine driven by a `time.Timer` that is re-armed only after a poll completes, so a poll that outruns the interval delays the next one instead of being followed by a queued tick. The first poll runs immediately rather than after a full interval.
- Each poll records the streams, consumers and peers it saw; the next poll deletes the series of whatever disappeared. A partial listing skips pruning, so a truncated poll cannot wipe live series.
- `Stop` cancels the context, drains the goroutine through a `sync.WaitGroup`, then closes the connection. `gatherData` never holds the lock across NATS I/O.
- New `Options.JSConfigPollInterval`. Zero (the default) means **disabled** — `NewSurveyor` does not construct the listener, nothing registers, nothing connects, no goroutine. Intervals below `MinJSConfigPollInterval` (1s) are rejected with an error rather than silently defaulted.
- CLI flag: `--js-config-poll-interval <duration>` (default `0`). Not `jsz-`, because this calls the JetStream client API rather than the jsz monitoring endpoint.
- Single-server / R1 deployments: `Cluster == nil` is detected and the peer metrics are simply not emitted; everything else still works.

## Credentials

This uses the **JetStream API**, which the system account the surveyor normally connects with cannot use. It reuses the main `--creds` / `--user` / `--password` options, so those have to belong to the JetStream account being observed. Keeping the surface minimal for this first cut; a config-file pattern like `--observe` / `--jetstream` could be added later if there is interest.

## Cost and cardinality

Worth calling out explicitly, and documented in both the flag help and the README:

- Every poll issues one `$JS.API.STREAM.LIST` page per 256 streams, plus one `$JS.API.CONSUMER.LIST` per stream that has consumers. In clustered mode the meta leader serves all of them by scatter-gathering to every stream and consumer leader, unlike the jsz path which polls each server directly. Streams reporting zero consumers skip the `CONSUMER.LIST` entirely, and stream handles are cached across polls so listing consumers costs no extra `STREAM.INFO`. On a large multi-tenant cluster the interval should still be measured in tens of seconds; 60s is a reasonable starting point.
- Cardinality scales with streams x consumers x replicas. Mutable state — leadership, peer current/offline, lag, sequence numbers, ack-pending limits — is only ever a gauge *value*, never a label, so series count is bounded by the assets themselves and series churn from leader flaps or config changes is avoided.

## Background

Adapted from a fork that has been running this listener in production at Snapp/Baly for ~18 months, refactored to fit upstream conventions before submitting.

## Test plan

- [x] `go build ./...` passes
- [x] `go vet ./...` and `golangci-lint run` pass
- [x] `go test ./...` passes (cmd, surveyor, test packages)
- [x] New `surveyor/jetstream_configs_test.go`: interval validation, a full poll against a JetStream server asserting config and limit values, verification that a non-clustered server emits no peer series, and that a deleted stream's series (and its consumers') are pruned on the next poll
- [ ] Manual: enable `--js-config-poll-interval=60s` against a JetStream cluster and verify the peer and lag metrics against a deliberately lagging replica
- [ ] Manual: verify default (no flag) is unchanged — no new connections, no new registered metrics
