### PR TITLE
Replace hardcoded rate windows ([1m], [5m]) with $__rate_interval

### DIFF
--- a/docker-compose/grafana/provisioning/dashboards/clients-dashboard.json
+++ b/docker-compose/grafana/provisioning/dashboards/clients-dashboard.json
@@ -192,7 +192,7 @@
       "pluginVersion": "7.1.1",
       "targets": [
         {
-          "expr": "sum(rate(nats_core_total_connection_count{server_cluster=~\"$cluster\"}[1m]))",
+          "expr": "sum(rate(nats_core_total_connection_count{server_cluster=~\"$cluster\"}[$__rate_interval]))",
           "interval": "",
           "legendFormat": "Connections / Second",
           "refId": "A"
@@ -477,7 +477,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(nats_core_total_connection_count{server_cluster=~\"$cluster\"}[1m])",
+              "expr": "rate(nats_core_total_connection_count{server_cluster=~\"$cluster\"}[$__rate_interval])",
               "interval": "",
               "legendFormat": "{{server_name}}",
               "refId": "A"
@@ -581,7 +581,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(nats_core_slow_consumer_count{server_cluster=~\"$cluster\"}[1m])",
+              "expr": "rate(nats_core_slow_consumer_count{server_cluster=~\"$cluster\"}[$__rate_interval])",
               "legendFormat": "{{server_name}}",
               "refId": "A"
             }

--- a/docker-compose/grafana/provisioning/dashboards/clusters-dashboard.json
+++ b/docker-compose/grafana/provisioning/dashboards/clusters-dashboard.json
@@ -206,13 +206,13 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(rate(nats_core_route_sent_bytes{server_cluster=~\"$cluster\"}[1m]))",
+          "expr": "sum(rate(nats_core_route_sent_bytes{server_cluster=~\"$cluster\"}[$__rate_interval]))",
           "interval": "",
           "legendFormat": "Sent",
           "refId": "A"
         },
         {
-          "expr": "sum(rate(nats_core_route_recv_bytes{server_cluster=~\"$cluster\"}[1m]))",
+          "expr": "sum(rate(nats_core_route_recv_bytes{server_cluster=~\"$cluster\"}[$__rate_interval]))",
           "interval": "",
           "legendFormat": "Received",
           "refId": "B"
@@ -320,14 +320,14 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(rate(nats_core_route_sent_msg_count{server_cluster=~\"$cluster\"}[1m]))",
+          "expr": "sum(rate(nats_core_route_sent_msg_count{server_cluster=~\"$cluster\"}[$__rate_interval]))",
           "hide": false,
           "interval": "",
           "legendFormat": "Sent",
           "refId": "A"
         },
         {
-          "expr": "sum(rate(nats_core_route_recv_msg_count{server_cluster=~\"$cluster\"}[1m]))",
+          "expr": "sum(rate(nats_core_route_recv_msg_count{server_cluster=~\"$cluster\"}[$__rate_interval]))",
           "interval": "",
           "legendFormat": "Received",
           "refId": "B"
@@ -444,7 +444,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(nats_core_route_sent_msg_count{server_cluster=~\"$cluster\"}[1m])",
+              "expr": "rate(nats_core_route_sent_msg_count{server_cluster=~\"$cluster\"}[$__rate_interval])",
               "interval": "",
               "legendFormat": "Server {{server_name}} - Route {{server_route_name}}",
               "refId": "A"
@@ -546,7 +546,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(nats_core_route_recv_msg_count{server_cluster=~\"$cluster\"}[1m])",
+              "expr": "rate(nats_core_route_recv_msg_count{server_cluster=~\"$cluster\"}[$__rate_interval])",
               "interval": "",
               "legendFormat": "Server {{server_name}} - Route {{server_route_name}}",
               "refId": "A"
@@ -666,7 +666,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(nats_core_route_sent_bytes{server_cluster=~\"$cluster\"}[1m])",
+              "expr": "rate(nats_core_route_sent_bytes{server_cluster=~\"$cluster\"}[$__rate_interval])",
               "interval": "",
               "legendFormat": "Server {{server_name}} - Route {{server_route_name}}",
               "refId": "A"
@@ -768,7 +768,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(nats_core_route_recv_bytes{server_cluster=~\"$cluster\"}[1m])",
+              "expr": "rate(nats_core_route_recv_bytes{server_cluster=~\"$cluster\"}[$__rate_interval])",
               "legendFormat": "Server {{server_name}} - Route {{server_route_name}}",
               "refId": "A"
             }

--- a/docker-compose/grafana/provisioning/dashboards/nats-surveyor-dashboard.json
+++ b/docker-compose/grafana/provisioning/dashboards/nats-surveyor-dashboard.json
@@ -4981,7 +4981,7 @@
           "pluginVersion": "8.3.4",
           "targets": [
             {
-              "expr": "increase(nats_survey_nats_reconnects[5m])",
+              "expr": "increase(nats_survey_nats_reconnects[1m])",
               "legendFormat": "Reconnections",
               "refId": "A"
             }
@@ -5069,7 +5069,7 @@
           "pluginVersion": "8.3.4",
           "targets": [
             {
-              "expr": " rate(nats_survey_duration_seconds_sum[5m])\n/\n  rate(nats_survey_duration_seconds_count[5m])",
+              "expr": " rate(nats_survey_duration_seconds_sum[$__rate_interval])\n/\n  rate(nats_survey_duration_seconds_count[$__rate_interval])",
               "legendFormat": "Poll Time",
               "refId": "A"
             }

--- a/docker-compose/grafana/provisioning/dashboards/nats-surveyor-dashboard.json
+++ b/docker-compose/grafana/provisioning/dashboards/nats-surveyor-dashboard.json
@@ -4897,12 +4897,12 @@
           "pluginVersion": "8.3.4",
           "targets": [
             {
-              "expr": "rate(nats_core_rtt_nanoseconds[$__rate_interval])",
+              "expr": "nats_core_rtt_nanoseconds",
               "legendFormat": "{{server_name}}",
               "refId": "A"
             }
           ],
-          "title": "Cluster RTT",
+          "title": "Cluster RTT per server",
           "type": "timeseries"
         },
         {

--- a/docker-compose/grafana/provisioning/dashboards/nats-surveyor-dashboard.json
+++ b/docker-compose/grafana/provisioning/dashboards/nats-surveyor-dashboard.json
@@ -88,7 +88,7 @@
       "pluginVersion": "8.3.4",
       "targets": [
         {
-          "expr": "sum(rate(nats_core_recv_msgs_count{server_cluster=~\"$cluster\"}[1m]))",
+          "expr": "sum(rate(nats_core_recv_msgs_count{server_cluster=~\"$cluster\"}[$__rate_interval]))",
           "legendFormat": "Received",
           "refId": "A"
         }
@@ -162,7 +162,7 @@
       "pluginVersion": "8.3.4",
       "targets": [
         {
-          "expr": "sum(rate(nats_core_sent_msgs_count{server_cluster=~\"$cluster\"}[1m]))",
+          "expr": "sum(rate(nats_core_sent_msgs_count{server_cluster=~\"$cluster\"}[$__rate_interval]))",
           "legendFormat": "Sent",
           "refId": "A"
         }
@@ -236,7 +236,7 @@
       "pluginVersion": "8.3.4",
       "targets": [
         {
-          "expr": "sum(rate(nats_core_recv_bytes{server_cluster=~\"$cluster\"}[1m]))",
+          "expr": "sum(rate(nats_core_recv_bytes{server_cluster=~\"$cluster\"}[$__rate_interval]))",
           "legendFormat": "Received",
           "refId": "A"
         }
@@ -310,7 +310,7 @@
       "pluginVersion": "8.3.4",
       "targets": [
         {
-          "expr": "sum(rate(nats_core_sent_bytes{server_cluster=~\"$cluster\"}[1m]))",
+          "expr": "sum(rate(nats_core_sent_bytes{server_cluster=~\"$cluster\"}[$__rate_interval]))",
           "legendFormat": "Sent",
           "refId": "A"
         }
@@ -457,7 +457,7 @@
       "pluginVersion": "8.3.4",
       "targets": [
         {
-          "expr": "sum(rate(nats_core_slow_consumer_count{server_cluster=~\"$cluster\"}[1m]))",
+          "expr": "sum(rate(nats_core_slow_consumer_count{server_cluster=~\"$cluster\"}[$__rate_interval]))",
           "legendFormat": "Slow",
           "refId": "A"
         }
@@ -1794,7 +1794,7 @@
               "type": "linear"
             },
             "showPoints": "never",
-            "spanNulls": true,
+            "spanNulls": false,
             "stacking": {
               "group": "A",
               "mode": "none"
@@ -1847,7 +1847,7 @@
       "pluginVersion": "8.3.4",
       "targets": [
         {
-          "expr": "sum(rate(nats_core_slow_consumer_count{server_cluster=~\"$cluster\"}[1m]))",
+          "expr": "sum(rate(nats_core_slow_consumer_count{server_cluster=~\"$cluster\"}[$__rate_interval]))",
           "legendFormat": "Slow Consumers",
           "refId": "A"
         }
@@ -1885,7 +1885,7 @@
               "type": "linear"
             },
             "showPoints": "never",
-            "spanNulls": true,
+            "spanNulls": false,
             "stacking": {
               "group": "A",
               "mode": "normal"
@@ -1976,7 +1976,7 @@
               "type": "linear"
             },
             "showPoints": "never",
-            "spanNulls": true,
+            "spanNulls": false,
             "stacking": {
               "group": "A",
               "mode": "normal"
@@ -2243,7 +2243,7 @@
               "type": "linear"
             },
             "showPoints": "never",
-            "spanNulls": true,
+            "spanNulls": false,
             "stacking": {
               "group": "A",
               "mode": "none"
@@ -2297,12 +2297,12 @@
       "pluginVersion": "8.3.4",
       "targets": [
         {
-          "expr": "sum(rate(nats_core_sent_msgs_count{server_cluster=~\"$cluster\"}[1m]))",
+          "expr": "sum(rate(nats_core_sent_msgs_count{server_cluster=~\"$cluster\"}[$__rate_interval]))",
           "legendFormat": "Sent",
           "refId": "A"
         },
         {
-          "expr": "sum(rate(nats_core_recv_msgs_count{server_cluster=~\"$cluster\"}[1m]))",
+          "expr": "sum(rate(nats_core_recv_msgs_count{server_cluster=~\"$cluster\"}[$__rate_interval]))",
           "legendFormat": "Received",
           "refId": "B"
         }
@@ -2340,7 +2340,7 @@
               "type": "linear"
             },
             "showPoints": "never",
-            "spanNulls": true,
+            "spanNulls": false,
             "stacking": {
               "group": "A",
               "mode": "none"
@@ -2395,12 +2395,12 @@
       "pluginVersion": "8.3.4",
       "targets": [
         {
-          "expr": "sum(rate(nats_core_sent_bytes{server_cluster=~\"$cluster\"}[1m]))",
+          "expr": "sum(rate(nats_core_sent_bytes{server_cluster=~\"$cluster\"}[$__rate_interval]))",
           "legendFormat": "Sent",
           "refId": "A"
         },
         {
-          "expr": "sum(rate(nats_core_recv_bytes{server_cluster=~\"$cluster\"}[1m]))",
+          "expr": "sum(rate(nats_core_recv_bytes{server_cluster=~\"$cluster\"}[$__rate_interval]))",
           "legendFormat": "Received",
           "refId": "B"
         }
@@ -2438,7 +2438,7 @@
               "type": "linear"
             },
             "showPoints": "never",
-            "spanNulls": true,
+            "spanNulls": false,
             "stacking": {
               "group": "A",
               "mode": "none"
@@ -2593,7 +2593,7 @@
                   "type": "linear"
                 },
                 "showPoints": "never",
-                "spanNulls": true,
+                "spanNulls": false,
                 "stacking": {
                   "group": "A",
                   "mode": "none"
@@ -2680,7 +2680,7 @@
                   "type": "linear"
                 },
                 "showPoints": "never",
-                "spanNulls": true,
+                "spanNulls": false,
                 "stacking": {
                   "group": "A",
                   "mode": "none"
@@ -2768,7 +2768,7 @@
                   "type": "linear"
                 },
                 "showPoints": "never",
-                "spanNulls": true,
+                "spanNulls": false,
                 "stacking": {
                   "group": "A",
                   "mode": "none"
@@ -2822,7 +2822,7 @@
           "pluginVersion": "8.3.4",
           "targets": [
             {
-              "expr": "rate(nats_core_total_connection_count{server_cluster=~\"$cluster\"}[1m])",
+              "expr": "rate(nats_core_total_connection_count{server_cluster=~\"$cluster\"}[$__rate_interval])",
               "legendFormat": "{{server_name}}",
               "refId": "A"
             }
@@ -2856,7 +2856,7 @@
                   "type": "linear"
                 },
                 "showPoints": "never",
-                "spanNulls": true,
+                "spanNulls": false,
                 "stacking": {
                   "group": "A",
                   "mode": "none"
@@ -2941,7 +2941,7 @@
                   "type": "linear"
                 },
                 "showPoints": "never",
-                "spanNulls": true,
+                "spanNulls": false,
                 "stacking": {
                   "group": "A",
                   "mode": "none"
@@ -2995,7 +2995,7 @@
           "pluginVersion": "8.3.4",
           "targets": [
             {
-              "expr": "rate(nats_core_slow_consumer_count{server_cluster=~\"$cluster\"}[1m])",
+              "expr": "rate(nats_core_slow_consumer_count{server_cluster=~\"$cluster\"}[$__rate_interval])",
               "legendFormat": "{{server_name}}",
               "refId": "A"
             }
@@ -3043,7 +3043,7 @@
                   "type": "linear"
                 },
                 "showPoints": "never",
-                "spanNulls": true,
+                "spanNulls": false,
                 "stacking": {
                   "group": "A",
                   "mode": "none"
@@ -3098,7 +3098,7 @@
           "pluginVersion": "8.3.4",
           "targets": [
             {
-              "expr": "rate(nats_core_gateway_sent_bytes{server_cluster=~\"$cluster\"}[1m])",
+              "expr": "rate(nats_core_gateway_sent_bytes{server_cluster=~\"$cluster\"}[$__rate_interval])",
               "legendFormat": "{{server_name}} - {{server_cluster}} -> {{server_gateway_name}}",
               "refId": "A"
             }
@@ -3132,7 +3132,7 @@
                   "type": "linear"
                 },
                 "showPoints": "never",
-                "spanNulls": true,
+                "spanNulls": false,
                 "stacking": {
                   "group": "A",
                   "mode": "none"
@@ -3186,7 +3186,7 @@
           "pluginVersion": "8.3.4",
           "targets": [
             {
-              "expr": "rate(nats_core_gateway_recv_bytes{server_cluster=~\"$cluster\"}[1m])",
+              "expr": "rate(nats_core_gateway_recv_bytes{server_cluster=~\"$cluster\"}[$__rate_interval])",
               "legendFormat": "{{server_name}} - {{server_cluster}} -> {{server_gateway_name}}",
               "refId": "A"
             }
@@ -3220,7 +3220,7 @@
                   "type": "linear"
                 },
                 "showPoints": "never",
-                "spanNulls": true,
+                "spanNulls": false,
                 "stacking": {
                   "group": "A",
                   "mode": "none"
@@ -3274,7 +3274,7 @@
           "pluginVersion": "8.3.4",
           "targets": [
             {
-              "expr": "rate(nats_core_gateway_sent_msgs_count{server_cluster=~\"$cluster\"}[1m])",
+              "expr": "rate(nats_core_gateway_sent_msgs_count{server_cluster=~\"$cluster\"}[$__rate_interval])",
               "legendFormat": "{{server_name}} - {{server_cluster}} -> {{server_gateway_name}}",
               "refId": "A"
             }
@@ -3308,7 +3308,7 @@
                   "type": "linear"
                 },
                 "showPoints": "never",
-                "spanNulls": true,
+                "spanNulls": false,
                 "stacking": {
                   "group": "A",
                   "mode": "none"
@@ -3362,7 +3362,7 @@
           "pluginVersion": "8.3.4",
           "targets": [
             {
-              "expr": "rate(nats_core_gateway_recv_msg_count{server_cluster=~\"$cluster\"}[1m])",
+              "expr": "rate(nats_core_gateway_recv_msg_count{server_cluster=~\"$cluster\"}[$__rate_interval])",
               "legendFormat": "{{server_name}} - {{server_cluster}} -> {{server_gateway_name}}",
               "refId": "A"
             }
@@ -3410,7 +3410,7 @@
                   "type": "linear"
                 },
                 "showPoints": "never",
-                "spanNulls": true,
+                "spanNulls": false,
                 "stacking": {
                   "group": "A",
                   "mode": "none"
@@ -3464,7 +3464,7 @@
           "pluginVersion": "8.3.4",
           "targets": [
             {
-              "expr": "rate(nats_core_route_sent_bytes{server_cluster=~\"$cluster\"}[1m])",
+              "expr": "rate(nats_core_route_sent_bytes{server_cluster=~\"$cluster\"}[$__rate_interval])",
               "legendFormat": "Server {{server_name}} - Route {{server_route_name}}",
               "refId": "A"
             }
@@ -3498,7 +3498,7 @@
                   "type": "linear"
                 },
                 "showPoints": "never",
-                "spanNulls": true,
+                "spanNulls": false,
                 "stacking": {
                   "group": "A",
                   "mode": "none"
@@ -3552,7 +3552,7 @@
           "pluginVersion": "8.3.4",
           "targets": [
             {
-              "expr": "rate(nats_core_route_recv_bytes{server_cluster=~\"$cluster\"}[1m])",
+              "expr": "rate(nats_core_route_recv_bytes{server_cluster=~\"$cluster\"}[$__rate_interval])",
               "legendFormat": "Server {{server_name}} - Route {{server_route_name}}",
               "refId": "A"
             }
@@ -3586,7 +3586,7 @@
                   "type": "linear"
                 },
                 "showPoints": "never",
-                "spanNulls": true,
+                "spanNulls": false,
                 "stacking": {
                   "group": "A",
                   "mode": "none"
@@ -3640,7 +3640,7 @@
           "pluginVersion": "8.3.4",
           "targets": [
             {
-              "expr": "rate(nats_core_route_sent_msg_count{server_cluster=~\"$cluster\"}[1m])",
+              "expr": "rate(nats_core_route_sent_msg_count{server_cluster=~\"$cluster\"}[$__rate_interval])",
               "legendFormat": "Server {{server_name}} - Route {{server_route_name}}",
               "refId": "A"
             }
@@ -3674,7 +3674,7 @@
                   "type": "linear"
                 },
                 "showPoints": "never",
-                "spanNulls": true,
+                "spanNulls": false,
                 "stacking": {
                   "group": "A",
                   "mode": "none"
@@ -3728,7 +3728,7 @@
           "pluginVersion": "8.3.4",
           "targets": [
             {
-              "expr": "rate(nats_core_route_recv_msg_count{server_cluster=~\"$cluster\"}[1m])",
+              "expr": "rate(nats_core_route_recv_msg_count{server_cluster=~\"$cluster\"}[$__rate_interval])",
               "legendFormat": "Server {{server_name}} - Route {{server_route_name}}",
               "refId": "A"
             }
@@ -3762,7 +3762,7 @@
                   "type": "linear"
                 },
                 "showPoints": "never",
-                "spanNulls": true,
+                "spanNulls": false,
                 "stacking": {
                   "group": "A",
                   "mode": "none"
@@ -3850,7 +3850,7 @@
                   "type": "linear"
                 },
                 "showPoints": "never",
-                "spanNulls": true,
+                "spanNulls": false,
                 "stacking": {
                   "group": "A",
                   "mode": "none"
@@ -4009,7 +4009,7 @@
           "pluginVersion": "8.3.4",
           "targets": [
             {
-              "expr": "rate(nats_core_sent_to_client_msgs_total{server_cluster=~\"$cluster\"}[1m])",
+              "expr": "rate(nats_core_sent_to_client_msgs_total{server_cluster=~\"$cluster\"}[$__rate_interval])",
               "legendFormat": "{{server_name}}",
               "refId": "A"
             }
@@ -4100,7 +4100,7 @@
           "pluginVersion": "8.3.4",
           "targets": [
             {
-              "expr": "rate(nats_core_recv_from_client_msgs_total{server_cluster=~\"$cluster\"}[1m])",
+              "expr": "rate(nats_core_recv_from_client_msgs_total{server_cluster=~\"$cluster\"}[$__rate_interval])",
               "legendFormat": "{{server_name}}",
               "refId": "A"
             }
@@ -4191,7 +4191,7 @@
           "pluginVersion": "8.3.4",
           "targets": [
             {
-              "expr": "rate(nats_core_sent_to_client_bytes_total{server_cluster=~\"$cluster\"}[1m])",
+              "expr": "rate(nats_core_sent_to_client_bytes_total{server_cluster=~\"$cluster\"}[$__rate_interval])",
               "legendFormat": "{{server_name}}",
               "refId": "A"
             }
@@ -4282,7 +4282,7 @@
           "pluginVersion": "8.3.4",
           "targets": [
             {
-              "expr": "rate(nats_core_recv_from_client_bytes_total{server_cluster=~\"$cluster\"}[1m])",
+              "expr": "rate(nats_core_recv_from_client_bytes_total{server_cluster=~\"$cluster\"}[$__rate_interval])",
               "legendFormat": "{{server_name}}",
               "refId": "A"
             }
@@ -4334,7 +4334,7 @@
                   "type": "linear"
                 },
                 "showPoints": "never",
-                "spanNulls": true,
+                "spanNulls": false,
                 "stacking": {
                   "group": "A",
                   "mode": "none"
@@ -4425,7 +4425,7 @@
                   "type": "linear"
                 },
                 "showPoints": "never",
-                "spanNulls": true,
+                "spanNulls": false,
                 "stacking": {
                   "group": "A",
                   "mode": "none"
@@ -4548,7 +4548,7 @@
                   "type": "linear"
                 },
                 "showPoints": "never",
-                "spanNulls": true,
+                "spanNulls": false,
                 "stacking": {
                   "group": "A",
                   "mode": "none"
@@ -4635,7 +4635,7 @@
                 "lineWidth": 2,
                 "fillOpacity": 10,
                 "gradientMode": "none",
-                "spanNulls": true,
+                "spanNulls": false,
                 "insertNulls": false,
                 "showPoints": "never",
                 "pointSize": 5,
@@ -4752,7 +4752,7 @@
                   "type": "linear"
                 },
                 "showPoints": "never",
-                "spanNulls": true,
+                "spanNulls": false,
                 "stacking": {
                   "group": "A",
                   "mode": "none"
@@ -4844,7 +4844,7 @@
                   "type": "linear"
                 },
                 "showPoints": "never",
-                "spanNulls": true,
+                "spanNulls": false,
                 "stacking": {
                   "group": "A",
                   "mode": "none"
@@ -4897,7 +4897,7 @@
           "pluginVersion": "8.3.4",
           "targets": [
             {
-              "expr": "rate(nats_core_rtt_nanoseconds[1m])",
+              "expr": "rate(nats_core_rtt_nanoseconds[$__rate_interval])",
               "legendFormat": "{{server_name}}",
               "refId": "A"
             }
@@ -4931,7 +4931,7 @@
                   "type": "linear"
                 },
                 "showPoints": "never",
-                "spanNulls": true,
+                "spanNulls": false,
                 "stacking": {
                   "group": "A",
                   "mode": "none"
@@ -5015,7 +5015,7 @@
                   "type": "linear"
                 },
                 "showPoints": "never",
-                "spanNulls": true,
+                "spanNulls": false,
                 "stacking": {
                   "group": "A",
                   "mode": "none"

--- a/docker-compose/grafana/provisioning/dashboards/natsoverview-dashboard.json
+++ b/docker-compose/grafana/provisioning/dashboards/natsoverview-dashboard.json
@@ -165,7 +165,7 @@
       "pluginVersion": "7.1.1",
       "targets": [
         {
-          "expr": "sum(rate(nats_core_total_connection_count{server_cluster=~\"$cluster\"}[1m]))",
+          "expr": "sum(rate(nats_core_total_connection_count{server_cluster=~\"$cluster\"}[$__rate_interval]))",
           "interval": "",
           "legendFormat": "Connections / sec",
           "refId": "A"
@@ -222,7 +222,7 @@
       "pluginVersion": "7.1.1",
       "targets": [
         {
-          "expr": "(sum(rate(nats_core_sent_msgs_count{server_cluster=~\"$cluster\"}[1m])) + sum(rate(nats_core_recv_msgs_count{server_cluster=~\"$cluster\"}[1m])))",
+          "expr": "(sum(rate(nats_core_sent_msgs_count{server_cluster=~\"$cluster\"}[$__rate_interval])) + sum(rate(nats_core_recv_msgs_count{server_cluster=~\"$cluster\"}[$__rate_interval])))",
           "interval": "",
           "legendFormat": "Messages/sec",
           "refId": "A"

--- a/docker-compose/grafana/provisioning/dashboards/network-dashboard.json
+++ b/docker-compose/grafana/provisioning/dashboards/network-dashboard.json
@@ -885,7 +885,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(nats_core_rtt_nanoseconds[$__rate_interval])",
+              "expr": "nats_core_rtt_nanoseconds",
               "legendFormat": "{{server_name}}",
               "refId": "A"
             }

--- a/docker-compose/grafana/provisioning/dashboards/network-dashboard.json
+++ b/docker-compose/grafana/provisioning/dashboards/network-dashboard.json
@@ -75,7 +75,7 @@
       "pluginVersion": "7.1.1",
       "targets": [
         {
-          "expr": "(sum(rate(nats_core_sent_bytes{server_cluster=~\"$cluster\"}[1m])) + sum(rate(nats_core_recv_bytes{server_cluster=~\"$cluster\"}[1m])))",
+          "expr": "(sum(rate(nats_core_sent_bytes{server_cluster=~\"$cluster\"}[$__rate_interval])) + sum(rate(nats_core_recv_bytes{server_cluster=~\"$cluster\"}[$__rate_interval])))",
           "interval": "",
           "legendFormat": "Bits/sec",
           "refId": "A"
@@ -132,7 +132,7 @@
       "pluginVersion": "7.1.1",
       "targets": [
         {
-          "expr": "(sum(rate(nats_core_sent_msgs_count{server_cluster=~\"$cluster\"}[1m])) + sum(rate(nats_core_recv_msgs_count{server_cluster=~\"$cluster\"}[1m])))",
+          "expr": "(sum(rate(nats_core_sent_msgs_count{server_cluster=~\"$cluster\"}[$__rate_interval])) + sum(rate(nats_core_recv_msgs_count{server_cluster=~\"$cluster\"}[$__rate_interval])))",
           "interval": "",
           "legendFormat": "Messages/sec",
           "refId": "A"
@@ -218,13 +218,13 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(rate(nats_core_sent_bytes{server_cluster=~\"$cluster\"}[1m]))",
+              "expr": "sum(rate(nats_core_sent_bytes{server_cluster=~\"$cluster\"}[$__rate_interval]))",
               "interval": "",
               "legendFormat": "Sent",
               "refId": "A"
             },
             {
-              "expr": "sum(rate(nats_core_recv_bytes{server_cluster=~\"$cluster\"}[1m]))",
+              "expr": "sum(rate(nats_core_recv_bytes{server_cluster=~\"$cluster\"}[$__rate_interval]))",
               "interval": "",
               "legendFormat": "Received",
               "refId": "B"
@@ -332,14 +332,14 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(rate(nats_core_sent_msgs_count{server_cluster=~\"$cluster\"}[1m]))",
+              "expr": "sum(rate(nats_core_sent_msgs_count{server_cluster=~\"$cluster\"}[$__rate_interval]))",
               "hide": false,
               "interval": "",
               "legendFormat": "Sent",
               "refId": "A"
             },
             {
-              "expr": "sum(rate(nats_core_recv_msgs_count{server_cluster=~\"$cluster\"}[1m]))",
+              "expr": "sum(rate(nats_core_recv_msgs_count{server_cluster=~\"$cluster\"}[$__rate_interval]))",
               "interval": "",
               "legendFormat": "Received",
               "refId": "B"
@@ -443,7 +443,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(nats_core_sent_bytes{server_cluster=~\"$cluster\"}[1m])",
+              "expr": "rate(nats_core_sent_bytes{server_cluster=~\"$cluster\"}[$__rate_interval])",
               "interval": "",
               "legendFormat": "{{server_name}}",
               "refId": "A"
@@ -546,7 +546,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(nats_core_recv_bytes{server_cluster=~\"$cluster\"}[1m])",
+              "expr": "rate(nats_core_recv_bytes{server_cluster=~\"$cluster\"}[$__rate_interval])",
               "legendFormat": "{{server_name}}",
               "refId": "A"
             }
@@ -666,7 +666,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(nats_core_sent_msgs_count{server_cluster=~\"$cluster\"}[1m])",
+              "expr": "rate(nats_core_sent_msgs_count{server_cluster=~\"$cluster\"}[$__rate_interval])",
               "interval": "",
               "legendFormat": "{{server_name}}",
               "refId": "A"
@@ -769,7 +769,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(nats_core_recv_msgs_count{server_cluster=~\"$cluster\"}[1m])",
+              "expr": "rate(nats_core_recv_msgs_count{server_cluster=~\"$cluster\"}[$__rate_interval])",
               "legendFormat": "{{server_name}}",
               "refId": "A"
             }
@@ -885,7 +885,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(nats_core_rtt_nanoseconds[1m])",
+              "expr": "rate(nats_core_rtt_nanoseconds[$__rate_interval])",
               "legendFormat": "{{server_name}}",
               "refId": "A"
             }

--- a/docker-compose/grafana/provisioning/dashboards/supercluster-dashboard.json
+++ b/docker-compose/grafana/provisioning/dashboards/supercluster-dashboard.json
@@ -220,13 +220,13 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(rate(nats_core_gateway_sent_bytes{server_cluster=~\"$cluster\"}[1m]))",
+              "expr": "sum(rate(nats_core_gateway_sent_bytes{server_cluster=~\"$cluster\"}[$__rate_interval]))",
               "interval": "",
               "legendFormat": "Sent",
               "refId": "A"
             },
             {
-              "expr": "sum(rate(nats_core_gateway_recv_bytes{server_cluster=~\"$cluster\"}[1m]))",
+              "expr": "sum(rate(nats_core_gateway_recv_bytes{server_cluster=~\"$cluster\"}[$__rate_interval]))",
               "interval": "",
               "legendFormat": "Received",
               "refId": "B"
@@ -329,7 +329,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(nats_core_gateway_sent_bytes{server_cluster=~\"$cluster\"}[1m])",
+              "expr": "rate(nats_core_gateway_sent_bytes{server_cluster=~\"$cluster\"}[$__rate_interval])",
               "legendFormat": "{{server_name}} - {{server_cluster}} -> {{server_gateway_name}}",
               "refId": "A"
             }
@@ -430,7 +430,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(nats_core_gateway_recv_bytes{server_cluster=~\"$cluster\"}[1m])",
+              "expr": "rate(nats_core_gateway_recv_bytes{server_cluster=~\"$cluster\"}[$__rate_interval])",
               "legendFormat": "{{server_name}} - {{server_cluster}} -> {{server_gateway_name}}",
               "refId": "A"
             }
@@ -555,14 +555,14 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(rate(nats_core_gateway_sent_msgs_count{server_cluster=~\"$cluster\"}[1m]))",
+              "expr": "sum(rate(nats_core_gateway_sent_msgs_count{server_cluster=~\"$cluster\"}[$__rate_interval]))",
               "hide": false,
               "interval": "",
               "legendFormat": "Sent",
               "refId": "A"
             },
             {
-              "expr": "sum(rate(nats_core_gateway_recv_msg_count{server_cluster=~\"$cluster\"}[1m]))",
+              "expr": "sum(rate(nats_core_gateway_recv_msg_count{server_cluster=~\"$cluster\"}[$__rate_interval]))",
               "interval": "",
               "legendFormat": "Received",
               "refId": "B"
@@ -665,7 +665,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(nats_core_gateway_sent_msgs_count{server_cluster=~\"$cluster\"}[1m])",
+              "expr": "rate(nats_core_gateway_sent_msgs_count{server_cluster=~\"$cluster\"}[$__rate_interval])",
               "interval": "",
               "legendFormat": "{{server_name}} - {{server_cluster}} -> {{server_gateway_name}}",
               "refId": "A"
@@ -767,7 +767,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(nats_core_gateway_recv_msg_count{server_cluster=~\"$cluster\"}[1m])",
+              "expr": "rate(nats_core_gateway_recv_msg_count{server_cluster=~\"$cluster\"}[$__rate_interval])",
               "legendFormat": "{{server_name}} - {{server_cluster}} -> {{server_gateway_name}}",
               "refId": "A"
             }


### PR DESCRIPTION
We had some newer panels use $__rate_interval, but some older ones use static [1m]
Grafana recommends to use `$__rate_interval`
https://grafana.com/docs/grafana/latest/datasources/prometheus/template-variables/#use-__rate_interval
since long time ago:
https://grafana.com/blog/new-in-grafana-7-2-rate-interval-for-prometheus-rate-queries-that-just-work/

Also, update panels to never connect nulls:
https://grafana.com/docs/grafana/latest/visualizations/panels-visualizations/visualizations/time-series/#connect-null-values
this is the default behavior: https://github.com/grafana/grafana/blob/v13.0.1/public/app/plugins/panel/timeseries/config.ts#L176-L181
And I think we want this, because we want to see gaps in data collection
