### PR TITLE
Fix CPU utilization graph

### DIFF
--- a/docker-compose/grafana/provisioning/dashboards/nats-surveyor-dashboard.json
+++ b/docker-compose/grafana/provisioning/dashboards/nats-surveyor-dashboard.json
@@ -4523,14 +4523,14 @@
             "type": "prometheus",
             "uid": "${prom_ds}"
           },
-          "description": "CPU used by the NATS Server process normalized by number of cores (% of total machine capacity)",
+          "description": "CPU used by the NATS Server process normalized by GOMAXPROCS",
           "fieldConfig": {
             "defaults": {
               "color": {
                 "mode": "palette-classic"
               },
               "custom": {
-                "axisLabel": "% of total CPU",
+                "axisLabel": "% usge of GOMAXPROCS CPU cores",
                 "axisPlacement": "auto",
                 "barAlignment": 0,
                 "drawStyle": "line",
@@ -4603,7 +4603,7 @@
           "pluginVersion": "8.3.4",
           "targets": [
             {
-              "expr": "nats_core_cpu_percentage{server_cluster=~\"$cluster\"} / nats_core_core_count{server_cluster=~\"$cluster\"}",
+              "expr": "nats_core_cpu_percentage{server_cluster=~\"$cluster\"} / nats_core_gomaxprocs{server_cluster=~\"$cluster\"}",
               "legendFormat": "{{server_name}}",
               "refId": "A"
             }

--- a/docker-compose/grafana/provisioning/dashboards/nats-surveyor-dashboard.json
+++ b/docker-compose/grafana/provisioning/dashboards/nats-surveyor-dashboard.json
@@ -4523,7 +4523,7 @@
             "type": "prometheus",
             "uid": "${prom_ds}"
           },
-          "description": "CPU used by the NATS Server process normalized by GOMAXPROCS",
+          "description": "CPU usage divided by GOMAXPROCS. 100% = all GOMAXPROCS threads fully utilized.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -4607,7 +4607,7 @@
               "refId": "A"
             }
           ],
-          "title": "CPU Usage (% normalized by GOMAXPROCS)",
+          "title": "CPU Utilization (% of GOMAXPROCS)",
           "type": "timeseries"
         },
         {
@@ -4615,9 +4615,10 @@
             "type": "prometheus",
             "uid": "${prom_ds}"
           },
+          "description": "Memory usage (RSS) divided by GOMEMLIMIT. 100% = process at memory limit.",
           "id": 85,
           "type": "timeseries",
-          "title": "Memory Usage (% of GOMEMLIMIT)",
+          "title": "Memory Utilization (% of GOMEMLIMIT)",
           "gridPos": {
             "x": 12,
             "y": 17,

--- a/docker-compose/grafana/provisioning/dashboards/nats-surveyor-dashboard.json
+++ b/docker-compose/grafana/provisioning/dashboards/nats-surveyor-dashboard.json
@@ -4530,7 +4530,6 @@
                 "mode": "palette-classic"
               },
               "custom": {
-                "axisLabel": "% usge of GOMAXPROCS CPU cores",
                 "axisPlacement": "auto",
                 "barAlignment": 0,
                 "drawStyle": "line",
@@ -4608,7 +4607,7 @@
               "refId": "A"
             }
           ],
-          "title": "CPU Usage (Normalized)",
+          "title": "CPU Usage (% normalized by GOMAXPROCS)",
           "type": "timeseries"
         },
         {

--- a/surveyor/collector_statz.go
+++ b/surveyor/collector_statz.go
@@ -60,6 +60,7 @@ type statzDescs struct {
 	Uptime              *GaugeVec
 	Mem                 *GaugeVec
 	GoMemLimit          *GaugeVec
+	GoMaxProcs          *GaugeVec
 	Cores               *GaugeVec
 	CPU                 *GaugeVec
 	Connections         *GaugeVec
@@ -398,6 +399,7 @@ func (sc *StatzCollector) buildDescs() {
 	sc.descs.Uptime = newGaugeVec(newName("uptime"), "Server uptime gauge", sc.constLabels, sc.serverLabels)
 	sc.descs.Mem = newGaugeVec(newName("mem_bytes"), "Server memory gauge", sc.constLabels, sc.serverLabels)
 	sc.descs.GoMemLimit = newGaugeVec(newName("go_memlimit_bytes"), "Server GOMEMLIMIT gauge (0 if not set)", sc.constLabels, sc.serverLabels)
+	sc.descs.GoMaxProcs = newGaugeVec(newName("gomaxprocs"), "Server GOMAXPROCS gauge (maximum number of threads to use for running goroutines at once)", sc.constLabels, sc.serverLabels)
 	sc.descs.Cores = newGaugeVec(newName("core_count"), "Machine cores gauge", sc.constLabels, sc.serverLabels)
 	sc.descs.CPU = newGaugeVec(newName("cpu_percentage"), "Server cpu utilization gauge", sc.constLabels, sc.serverLabels)
 	sc.descs.Connections = newGaugeVec(newName("connection_count"), "Current number of client connections gauge", sc.constLabels, sc.serverLabels)
@@ -1796,6 +1798,7 @@ func (sc *StatzCollector) Collect(ch chan<- prometheus.Metric) {
 				metrics.newGaugeMetric(sc.descs.Uptime, time.Since(sm.Stats.Start).Seconds(), labels)
 				metrics.newGaugeMetric(sc.descs.Mem, float64(sm.Stats.Mem), labels)
 				metrics.newGaugeMetric(sc.descs.GoMemLimit, float64(sm.Stats.MemLimit), labels)
+				metrics.newGaugeMetric(sc.descs.GoMaxProcs, float64(sm.Stats.MaxProcs), labels)
 				metrics.newGaugeMetric(sc.descs.Cores, float64(sm.Stats.Cores), labels)
 				metrics.newGaugeMetric(sc.descs.CPU, sm.Stats.CPU, labels)
 				metrics.newGaugeMetric(sc.descs.Connections, float64(sm.Stats.Connections), labels)

--- a/surveyor/collector_statz_test.go
+++ b/surveyor/collector_statz_test.go
@@ -421,6 +421,34 @@ func TestStatzCollector_GoMemLimit(t *testing.T) {
 	}
 }
 
+func TestStatzCollector_GoMaxProcs(t *testing.T) {
+	stats := &server.ServerStatsMsg{
+		Server: server.ServerInfo{
+			ID:   "test-server",
+			Name: "test-server",
+		},
+		Stats: server.ServerStats{
+			MaxProcs: 4,
+		},
+	}
+
+	sc, err := NewStatzCollectorOpts(
+		WithStats(WithStatsBatch{
+			Stats: []*server.ServerStatsMsg{stats},
+		}),
+	)
+	if err != nil {
+		t.Fatalf("error creating statz collector: %v", err)
+	}
+
+	output := gatherStatzCollectorMetrics(t, sc)
+
+	expectedMetric := "nats_core_gomaxprocs{server_cluster=\"\",server_id=\"test-server\",server_name=\"test-server\"} 4"
+	if !strings.Contains(output, expectedMetric) {
+		t.Fatalf("expected metric value not found. Expected: %s\nActual output:\n%v", expectedMetric, output)
+	}
+}
+
 func TestStatzCollector_ClientTrafficMetrics(t *testing.T) {
 	const (
 		sentMsgs  = 11


### PR DESCRIPTION
Normalize CPU utilization graph by GOMAXPROCS, not by number of cores.
Related: https://go.dev/blog/container-aware-gomaxprocs

<img width="2410" height="649" alt="image" src="https://github.com/user-attachments/assets/d2398746-04ad-4017-a61a-2a7ac4d99112" />


Fixes https://github.com/nats-io/nats-surveyor/issues/311